### PR TITLE
fix: remove duplicate interface

### DIFF
--- a/contracts/views/CurveView.sol
+++ b/contracts/views/CurveView.sol
@@ -4,10 +4,7 @@ pragma experimental ABIEncoderV2;
 
 import "../actions/curve/helpers/CurveHelper.sol";
 import "../interfaces/curve/ILiquidityGauge.sol";
-
-interface IERC20 {
-    function balanceOf(address) external view returns (uint256);
-}
+import "../interfaces/IERC20.sol";
 
 contract CurveView is CurveHelper {
     struct LpBalance {


### PR DESCRIPTION
The bug only affects hardhat tests, but it's annoying nontheless.