### PR TITLE
feat: create AaveUnstakeAction

### DIFF
--- a/addresses/mainnet.json
+++ b/addresses/mainnet.json
@@ -1065,6 +1065,17 @@
         "history": []
     },
     {
+        "name": "AaveUnstake",
+        "address": "0x2FE4024e350cD2c64D2fd0Db5d16F5cE54Ca0E09",
+        "id": "0x887729ae",
+        "path": "contracts/actions/aave/AaveUnstake.sol",
+        "version": "1.0.0",
+        "inRegistry": true,
+        "changeTime": "86400",
+        "registryIds": [],
+        "history": []
+    },
+    {
         "name": "MorphoMarketStorage",
         "address": "0x56EE33811a6C8c1Fd443E53685ed1605E43b3971",
         "id": "0x9600f04b",

--- a/contracts/actions/aave/AaveUnstake.sol
+++ b/contracts/actions/aave/AaveUnstake.sol
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity =0.8.10;
+pragma experimental ABIEncoderV2;
+
+import "../ActionBase.sol";
+import "./helpers/AaveHelper.sol";
+import "../../interfaces/aave/IStkAave.sol";
+import "../../utils/TokenUtils.sol";
+
+contract AaveUnstake is ActionBase, AaveHelper {
+    using TokenUtils for address;
+
+    /// @param amount amount of stkAave tokens to burn (max.uint to redeem whole balance)
+    /// @param to address to receive AAVE tokens
+    struct Params {
+        uint256 amount;
+        address to;
+    }
+
+    /// @inheritdoc ActionBase
+    function executeAction(
+        bytes memory _callData,
+        bytes32[] memory _subData,
+        uint8[] memory _paramMapping,
+        bytes32[] memory _returnValues
+    ) public payable virtual override returns (bytes32) {
+        Params memory params = parseInputs(_callData);
+
+        params.amount = _parseParamUint(params.amount, _paramMapping[0], _subData, _returnValues);
+
+        (uint256 claimedAmount, bytes memory logData) = _unstake(params);
+        emit ActionEvent("AaveStake", logData);
+        return bytes32(claimedAmount);
+    }
+
+    /// @inheritdoc ActionBase
+    function executeActionDirect(bytes memory _callData) public payable override {
+        Params memory params = parseInputs(_callData);
+        (, bytes memory logData) = _unstake(params);
+        logger.logActionDirectEvent("AaveStake", logData);
+    }
+
+    /// @inheritdoc ActionBase
+    function actionType() public pure virtual override returns (uint8) {
+        return uint8(ActionType.STANDARD_ACTION);
+    }
+
+    //////////////////////////// ACTION LOGIC ////////////////////////////
+
+    function _unstake(Params memory _params) internal returns (uint256 unstakedAmount, bytes memory logData) {
+
+        if (_params.amount == 0){
+            IStkAave(STAKED_TOKEN_ADDR).cooldown();
+        } else {
+            uint256 startingAAVEBalance = IStkAave(STAKED_TOKEN_ADDR).REWARD_TOKEN().getBalance(_params.to);
+            IStkAave(STAKED_TOKEN_ADDR).redeem(_params.to, _params.amount);
+            uint256 endingAAVEBalance = IStkAave(STAKED_TOKEN_ADDR).REWARD_TOKEN().getBalance(_params.to);
+
+            logData = abi.encode(_params, endingAAVEBalance - startingAAVEBalance);
+            return (endingAAVEBalance - startingAAVEBalance, logData);
+        }
+        
+    }
+    function parseInputs(bytes memory _callData) internal pure returns (Params memory params)
+    {
+        params = abi.decode(_callData, (Params));
+    }
+}

--- a/contracts/interfaces/aave/IStkAave.sol
+++ b/contracts/interfaces/aave/IStkAave.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity =0.8.10;
+
+abstract contract IStkAave {
+  function cooldown() external virtual;
+  function redeem(address to, uint256 amount) external virtual;
+  function REWARD_TOKEN() external virtual view returns (address);
+  function stake(address onBehalfOf, uint256 amount) external virtual;
+} 

--- a/test/aave/aave-unstake.js
+++ b/test/aave/aave-unstake.js
@@ -1,0 +1,16 @@
+const {
+    redeploy,
+} = require('../utils');
+
+const { aaveUnstakeTest } = require('./aave-tests');
+
+describe('Aave-Unstake', function () {
+    this.timeout(80000);
+
+    before(async () => {
+        await redeploy('AaveUnstake');
+    });
+    it('... should run aave unstake test', async () => {
+        await aaveUnstakeTest();
+    });
+});

--- a/test/actions.js
+++ b/test/actions.js
@@ -203,6 +203,20 @@ const claimStkAave = async (proxy, assets, amount, to) => {
     const tx = await executeAction('AaveClaimStkAave', functionData, proxy);
     return tx;
 };
+
+const startUnstakeAave = async (proxy) => {
+    const startUnstakeAction = new dfs.actions.aave.AaveStartUnstakeAction();
+    const functionData = startUnstakeAction.encodeForDsProxyCall()[1];
+    const tx = await executeAction('AaveUnstake', functionData, proxy);
+    return tx;
+};
+
+const finalizeUnstakeAave = async (proxy, to, amount) => {
+    const startUnstakeAction = new dfs.actions.aave.AaveFinalizeUnstakeAction(amount, to);
+    const functionData = startUnstakeAction.encodeForDsProxyCall()[1];
+    const tx = await executeAction('AaveUnstake', functionData, proxy);
+    return tx;
+};
 /*
 .______       _______  _______  __       __________   ___  _______ .______
 |   _  \     |   ____||   ____||  |     |   ____\  \ /  / |   ____||   _  \
@@ -2602,6 +2616,8 @@ module.exports = {
     borrowAave,
     paybackAave,
     claimStkAave,
+    startUnstakeAave,
+    finalizeUnstakeAave,
 
     supplyComp,
     withdrawComp,
@@ -2742,7 +2758,7 @@ module.exports = {
     morphoAaveV3Withdraw,
     morphoAaveV3Payback,
     morphoAaveV3Borrow,
-    
+
     bprotocolLiquitySPDeposit,
     bprotocolLiquitySPWithdraw,
 };


### PR DESCRIPTION
https://github.com/defisaver/defisaver-sdk/pull/81

Created one solidity contract for AaveUnstake, and two different sdk Actions to call depending on if you are starting to unstake or if you are finalizing unstaking.

I think we don't need AaveStake action as of now, as using StkAave.stake(onBehalfOf, amount), with onBehalfOf being proxy being much more gas optimised - the flow is in test and more info can be found here https://docs.aave.com/developers/v/2.0/protocol-governance/staking-aave#stake