### PR TITLE
fix: reimburse aave v2 position holders with up to 2 wei in AaveWithdraw

### DIFF
--- a/addresses/mainnet.json
+++ b/addresses/mainnet.json
@@ -1044,14 +1044,14 @@
     },
     {
         "name": "AaveWithdraw",
-        "address": "0x754C58fA92246414a448c1ed44ea3D1AD446d482",
+        "address": "0xee274301e8b06d2284c4c7ebfbd8f3a368ce24f2",
         "id": "0x4a76aaa3",
         "path": "contracts/actions/aave/AaveWithdraw.sol",
         "version": "1.0.0",
         "inRegistry": true,
         "changeTime": "86400",
         "registryIds": [],
-        "history": []
+        "history": ["0x754C58fA92246414a448c1ed44ea3D1AD446d482"]
     },
     {
         "name": "AaveCollateralSwitch",

--- a/contracts/actions/aave/AaveWithdraw.sol
+++ b/contracts/actions/aave/AaveWithdraw.sol
@@ -5,6 +5,7 @@ pragma solidity =0.8.10;
 import "../../utils/TokenUtils.sol";
 import "../ActionBase.sol";
 import "./helpers/AaveHelper.sol";
+import "../../utils/FLFeeFaucet.sol";
 
 /// @title Withdraw a token from an Aave market
 contract AaveWithdraw is ActionBase, AaveHelper {
@@ -63,14 +64,31 @@ contract AaveWithdraw is ActionBase, AaveHelper {
     ) internal returns (uint256, bytes memory) {
         ILendingPoolV2 lendingPool = getLendingPool(_market);
         uint256 tokenBefore;
+        uint256 amountToWithdraw = _amount;
 
         // only need to remember this is _amount is max, no need to waste gas otherwise
         if (_amount == type(uint256).max) {
             tokenBefore = _tokenAddr.getBalance(_to);
+        } else {
+            /// @dev sometimes aave eats one wei when supplying, this breaks our recipes
+            /// @dev here we do the check and send the difference to the receiving address
+            address aToken = lendingPool.getReserveData(_tokenAddr).aTokenAddress;
+            uint256 aTokenBalance = aToken.getBalance(address(this));
+
+            if (aTokenBalance < _amount) {
+                uint256 difference = _amount - aTokenBalance;
+
+                if (difference < 3) {
+                    FLFeeFaucet(DYDX_FL_FEE_FAUCET).my2Wei(_tokenAddr);
+                    _tokenAddr.withdrawTokens(_to, difference);
+                    _tokenAddr.withdrawTokens(DYDX_FL_FEE_FAUCET, 2 - difference);
+                    amountToWithdraw = aTokenBalance;
+                }
+            }
         }
 
         // withdraw underlying tokens from aave and send _to address
-        lendingPool.withdraw(_tokenAddr, _amount, _to);
+        lendingPool.withdraw(_tokenAddr, amountToWithdraw, _to);
 
         // if the input amount is max calc. what was the exact _amount
         if (_amount == type(uint256).max) {

--- a/contracts/actions/aave/helpers/MainnetAaveAddresses.sol
+++ b/contracts/actions/aave/helpers/MainnetAaveAddresses.sol
@@ -5,4 +5,5 @@ pragma solidity =0.8.10;
 contract MainnetAaveAddresses {
     address internal constant STAKED_CONTROLLER_ADDR = 0xd784927Ff2f95ba542BfC824c8a8a98F3495f6b5;
     address internal constant STAKED_TOKEN_ADDR = 0x4da27a545c0c5B758a6BA100e3a049001de870f5;
+    address internal constant DYDX_FL_FEE_FAUCET = 0x47f159C90850D5cE09E21F931d504536840f34b4;
 }

--- a/test/utils-aave.js
+++ b/test/utils-aave.js
@@ -1,7 +1,8 @@
 const hre = require('hardhat');
 
 const aaveV2assetsDefaultMarket = [
-    'ETH', 'DAI', 'BAT', 'ENJ', 'KNCL', 'LINK', 'MANA', 'MKR', 'REN', 'SNX', 'SUSD', 'TUSD', 'UNI', 'USDC', 'USDT', 'WBTC', 'YFI', 'ZRX', // 'BUSD', TODO: SOLVE BUSD LIQUIDITY PROBLEM
+    'ETH', 'DAI', 'SUSD', 'USDC', 'USDT', 'WBTC',
+    'CRV', 'AAVE',
 ];
 
 const AAVE_MARKET_DATA_ADDR = '0x057835Ad21a177dbdd3090bB1CAE03EaCF78Fc6d';


### PR DESCRIPTION
Aave has a bug in supply logic such that the user balance is sometimes off by one wei This commit fixes that so that the migration recipe doesnt revert at withdraw