### PR TITLE
feat: add script for adding contracts from json file to tenderly project

### DIFF
--- a/cmd/tenderly-cli.js
+++ b/cmd/tenderly-cli.js
@@ -1,0 +1,170 @@
+/* eslint-disable import/no-extraneous-dependencies */
+require('dotenv-safe').config();
+const fs = require('fs');
+const path = require('path');
+const axios = require('axios');
+const { program } = require('commander');
+
+const supportedNetworks = {
+    mainnet: '1',
+    arbitrum: '42161',
+    optimism: '10',
+    base: '8453',
+};
+
+const getNetworkId = (network) => supportedNetworks[network];
+
+const isNetworkSupported = (network) => Object.keys(supportedNetworks).includes(network);
+
+const readContractsFromJson = (network) => {
+    try {
+        const filePath = path.join(__dirname, '..', 'addresses', `${network}.json`);
+        const data = fs.readFileSync(filePath, 'utf8');
+        const contracts = JSON.parse(data);
+        return contracts;
+    } catch (error) {
+        console.error('Error reading or parsing the file', error);
+        return [];
+    }
+};
+
+const getContractsFromTenderly = async (networkId) => {
+    const url = 'https://api.tenderly.co/api/v1/account/defisaver-v2/project/strategies/contracts';
+    const headersParams = {
+        'Content-Type': 'application/json',
+        'X-Access-Key': process.env.TENDERLY_ACCESS_KEY,
+    };
+    try {
+        const response = await axios.get(url, { headers: headersParams });
+        return response.data
+            .filter((c) => c.contract.network_id === networkId)
+            .map((c) => ({ address: c.contract.address }));
+    } catch (error) {
+        console.error('Error getting contracts from tenderly', error);
+        return null;
+    }
+};
+
+const sendContractsToTenderly = async (contracts, networkId) => {
+    const url = 'https://api.tenderly.co/api/v2/accounts/defisaver-v2/projects/Strategies/contracts';
+    const headersParams = {
+        'Content-Type': 'application/json',
+        'X-Access-Key': process.env.TENDERLY_ACCESS_KEY,
+    };
+    const body = {
+        contracts: contracts.map((contract) => ({
+            network_id: networkId,
+            address: contract.address,
+            display_name: contract.name,
+        })),
+    };
+    try {
+        await axios.post(url, body, { headers: headersParams });
+        console.log('Contract(s) successfully sent to Tenderly');
+    } catch (error) {
+        console.error('Error sending contracts to Tenderly', error.response.data);
+    }
+};
+
+const sync = async (idOrNameOrAddress, options) => {
+    const network = options.network.length === 0 ? 'mainnet' : options.network;
+
+    if (!isNetworkSupported(network.toLowerCase())) {
+        console.error(`Error: Network '${network}' not supported`);
+        return;
+    }
+
+    const contracts = readContractsFromJson(network);
+
+    const found = contracts.find(
+        (c) => c.name === idOrNameOrAddress
+        || c.address === idOrNameOrAddress
+        || c.id === idOrNameOrAddress,
+    );
+
+    if (!found) {
+        console.error(`Error: Contract '${idOrNameOrAddress}' not found in '${network}.json'`);
+        return;
+    }
+
+    await sendContractsToTenderly([found], getNetworkId(network));
+};
+
+const findContractsToSync = (contractsFromJson, contractsFromTenderly, networkId) => {
+    const contractsFromTenderlyMap = {};
+    contractsFromTenderly.forEach((contract) => {
+        contractsFromTenderlyMap[contract.address.toLowerCase()] = contract;
+    });
+
+    const contractsToSync = [];
+    contractsFromJson.forEach((contract) => {
+        if (!contractsFromTenderlyMap[contract.address.toLowerCase()]) {
+            contractsToSync.push({
+                network_id: networkId,
+                address: contract.address,
+                display_name: contract.name,
+            });
+        }
+    });
+
+    return contractsToSync;
+};
+
+const syncAll = async (options) => {
+    const network = options.network.length === 0 ? 'mainnet' : options.network;
+
+    if (!isNetworkSupported(network.toLowerCase())) {
+        console.error(`Error: Network '${network}' not supported`);
+        return;
+    }
+
+    const networkId = getNetworkId(network);
+
+    const contractsFromTenderly = await getContractsFromTenderly(networkId);
+
+    if (contractsFromTenderly === null) {
+        return;
+    }
+
+    if (contractsFromTenderly.length === 0) {
+        console.log(`No contracts found in Tenderly for network: ${network}`);
+        return;
+    }
+
+    const contractsFromJson = readContractsFromJson(network);
+
+    const contractsToSync = findContractsToSync(
+        contractsFromJson, contractsFromTenderly, networkId,
+    );
+
+    if (contractsToSync.length === 0) {
+        console.log(`All contracts from ${network}.json are already in Tenderly`);
+        return;
+    }
+
+    console.log(`Syncing ${contractsToSync.length} contracts to Tenderly...`);
+
+    await sendContractsToTenderly(contractsToSync, networkId);
+};
+
+(async () => {
+    program
+        .command('sync <idOrNameOrAddress>')
+        .option('-n, --network <network>', 'Specify network (defaults to mainnet)', [])
+        .description('Add contract to tenderly project')
+        .action(async (idOrNameOrAddress, options) => {
+            await sync(idOrNameOrAddress, options);
+            process.exit(0);
+        });
+
+    program
+        .command('syncAll')
+        .option('-n, --network <network>', 'Specify network (defaults to mainnet)', [])
+        .description('Add all missing contracts to tenderly project')
+        .action(async (options) => {
+            await syncAll(options);
+            process.exit(0);
+        });
+
+    program.parse(process.argv);
+})();


### PR DESCRIPTION
**Script usage**

___________________
For single contract
`node cmd/tenderly-cli.js sync {ContractName/ContractAddress/Id} -n {network}`
Network is optional and defaults to mainnet
Example
`node cmd/tenderly-cli.js sync DFSRegistry -n arbitrum`

___________________
For all contracts
`node cmd/tenderly-cli.js syncAll -n {network}`
Network is optional and defaults to mainnet
Example
`node cmd/tenderly-cli.js syncAll -n arbitrum`