### PR TITLE
feat: vNet support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,8 @@ FORK_ID=insert_fork_id_here
 TENDERLY_USERNAME=insert_tenderly_username_here
 TENDERLY_PROJECT=insert_tenderly_project_here
 TENDERLY_ACCESS_KEY=insert_tenderly_access_key_here
+TENDERLY_AUTOMATIC_VERIFICATION=true
+TENDERLY_ENABLE_OUTDATED_VERSION_CHECK=false
 
 TEST_CHAIN_ID=mainnet
 

--- a/addresses/arbitrum.json
+++ b/addresses/arbitrum.json
@@ -1320,7 +1320,7 @@
       "path": "contracts/actions/fluid/vaultT1/FluidVaultT1Open",
       "version": "1.0.0",
       "inRegistry": true,
-      "changeTime": "0",
+      "changeTime": "86400",
       "registryIds": [],
       "history": []
   },
@@ -1331,7 +1331,7 @@
       "path": "contracts/actions/fluid/vaultT1/FluidVaultT1Supply",
       "version": "1.0.0",
       "inRegistry": true,
-      "changeTime": "0",
+      "changeTime": "86400",
       "registryIds": [],
       "history": []
   },
@@ -1342,7 +1342,7 @@
       "path": "contracts/actions/fluid/vaultT1/FluidVaultT1Withdraw",
       "version": "1.0.0",
       "inRegistry": true,
-      "changeTime": "0",
+      "changeTime": "86400",
       "registryIds": [],
       "history": []
   },
@@ -1353,7 +1353,7 @@
       "path": "contracts/actions/fluid/vaultT1/FluidVaultT1Borrow",
       "version": "1.0.0",
       "inRegistry": true,
-      "changeTime": "0",
+      "changeTime": "86400",
       "registryIds": [],
       "history": []
   },
@@ -1364,7 +1364,7 @@
       "path": "contracts/actions/fluid/vaultT1/FluidVaultT1Payback",
       "version": "1.0.0",
       "inRegistry": true,
-      "changeTime": "0",
+      "changeTime": "86400",
       "registryIds": [],
       "history": []
   },
@@ -1375,7 +1375,7 @@
       "path": "contracts/actions/fluid/vaultT1/FluidVaultT1Adjust",
       "version": "1.0.0",
       "inRegistry": true,
-      "changeTime": "0",
+      "changeTime": "86400",
       "registryIds": [],
       "history": []
   },
@@ -1386,7 +1386,7 @@
       "path": "contracts/actions/fluid/vaultT1/FluidRatioTrigger",
       "version": "1.0.0",
       "inRegistry": true,
-      "changeTime": "0",
+      "changeTime": "86400",
       "registryIds": [],
       "history": []
   },
@@ -1397,7 +1397,7 @@
       "path": "contracts/actions/fluid/vaultT1/FluidRatioCheck",
       "version": "1.0.0",
       "inRegistry": true,
-      "changeTime": "0",
+      "changeTime": "86400",
       "registryIds": [],
       "history": []
   },

--- a/addresses/base.json
+++ b/addresses/base.json
@@ -1281,7 +1281,7 @@
       "path": "contracts/actions/fluid/vaultT1/FluidVaultT1Open",
       "version": "1.0.0",
       "inRegistry": true,
-      "changeTime": "0",
+      "changeTime": "86400",
       "registryIds": [],
       "history": []
   },
@@ -1292,7 +1292,7 @@
       "path": "contracts/actions/fluid/vaultT1/FluidVaultT1Supply",
       "version": "1.0.0",
       "inRegistry": true,
-      "changeTime": "0",
+      "changeTime": "86400",
       "registryIds": [],
       "history": []
   },
@@ -1303,7 +1303,7 @@
       "path": "contracts/actions/fluid/vaultT1/FluidVaultT1Withdraw",
       "version": "1.0.0",
       "inRegistry": true,
-      "changeTime": "0",
+      "changeTime": "86400",
       "registryIds": [],
       "history": []
   },
@@ -1314,7 +1314,7 @@
       "path": "contracts/actions/fluid/vaultT1/FluidVaultT1Borrow",
       "version": "1.0.0",
       "inRegistry": true,
-      "changeTime": "0",
+      "changeTime": "86400",
       "registryIds": [],
       "history": []
   },
@@ -1325,7 +1325,7 @@
       "path": "contracts/actions/fluid/vaultT1/FluidVaultT1Payback",
       "version": "1.0.0",
       "inRegistry": true,
-      "changeTime": "0",
+      "changeTime": "86400",
       "registryIds": [],
       "history": []
   },
@@ -1336,7 +1336,7 @@
       "path": "contracts/actions/fluid/vaultT1/FluidVaultT1Adjust",
       "version": "1.0.0",
       "inRegistry": true,
-      "changeTime": "0",
+      "changeTime": "86400",
       "registryIds": [],
       "history": []
   },
@@ -1347,7 +1347,7 @@
       "path": "contracts/actions/fluid/vaultT1/FluidRatioTrigger",
       "version": "1.0.0",
       "inRegistry": true,
-      "changeTime": "0",
+      "changeTime": "86400",
       "registryIds": [],
       "history": []
   },
@@ -1358,7 +1358,7 @@
       "path": "contracts/actions/fluid/vaultT1/FluidRatioCheck",
       "version": "1.0.0",
       "inRegistry": true,
-      "changeTime": "0",
+      "changeTime": "86400",
       "registryIds": [],
       "history": []
   },

--- a/addresses/mainnet.json
+++ b/addresses/mainnet.json
@@ -4127,7 +4127,7 @@
         "path": "contracts/actions/fluid/vaultT1/FluidVaultT1Open",
         "version": "1.0.0",
         "inRegistry": true,
-        "changeTime": "0",
+        "changeTime": "86400",
         "registryIds": [],
         "history": []
     },
@@ -4138,7 +4138,7 @@
         "path": "contracts/actions/fluid/vaultT1/FluidVaultT1Supply",
         "version": "1.0.0",
         "inRegistry": true,
-        "changeTime": "0",
+        "changeTime": "86400",
         "registryIds": [],
         "history": []
     },
@@ -4149,7 +4149,7 @@
         "path": "contracts/actions/fluid/vaultT1/FluidVaultT1Withdraw",
         "version": "1.0.0",
         "inRegistry": true,
-        "changeTime": "0",
+        "changeTime": "86400",
         "registryIds": [],
         "history": []
     },
@@ -4160,7 +4160,7 @@
         "path": "contracts/actions/fluid/vaultT1/FluidVaultT1Borrow",
         "version": "1.0.0",
         "inRegistry": true,
-        "changeTime": "0",
+        "changeTime": "86400",
         "registryIds": [],
         "history": []
     },
@@ -4171,7 +4171,7 @@
         "path": "contracts/actions/fluid/vaultT1/FluidVaultT1Payback",
         "version": "1.0.0",
         "inRegistry": true,
-        "changeTime": "0",
+        "changeTime": "86400",
         "registryIds": [],
         "history": []
     },
@@ -4182,7 +4182,7 @@
         "path": "contracts/actions/fluid/vaultT1/FluidVaultT1Adjust",
         "version": "1.0.0",
         "inRegistry": true,
-        "changeTime": "0",
+        "changeTime": "86400",
         "registryIds": [],
         "history": []
     },
@@ -4193,7 +4193,7 @@
         "path": "contracts/actions/fluid/vaultT1/FluidRatioTrigger",
         "version": "1.0.0",
         "inRegistry": true,
-        "changeTime": "0",
+        "changeTime": "86400",
         "registryIds": [],
         "history": []
     },
@@ -4204,7 +4204,7 @@
         "path": "contracts/actions/fluid/vaultT1/FluidRatioCheck",
         "version": "1.0.0",
         "inRegistry": true,
-        "changeTime": "0",
+        "changeTime": "86400",
         "registryIds": [],
         "history": []
     },

--- a/cmd/forkooor.js
+++ b/cmd/forkooor.js
@@ -533,9 +533,9 @@ const cbRebondSub = async (bondId, sender) => {
 
 const liqCBPaybackSub = async (sourceId, sourceType, triggerRatio, triggerState, sender) => {
     let senderAcc = (await hre.ethers.getSigners())[0];
-    await redeploy('FetchBondId', REGISTRY_ADDR, false, true);
-    await redeploy('LiquityPayback', REGISTRY_ADDR, false, true);
-    await redeploy('CBCreateRebondSub', REGISTRY_ADDR, false, true);
+    await redeploy('FetchBondId', REGISTRY_ADDR, true);
+    await redeploy('LiquityPayback', REGISTRY_ADDR, true);
+    await redeploy('CBCreateRebondSub', REGISTRY_ADDR, true);
 
     let formattedPriceState;
 
@@ -569,7 +569,7 @@ const liqCBPaybackSub = async (sourceId, sourceType, triggerRatio, triggerState,
 const mcdTrailingCloseStrategySub = async (vaultId, type, percentage, isToDai, sender) => {
     let senderAcc = (await hre.ethers.getSigners())[0];
 
-    await redeploy('TrailingStopTrigger', REGISTRY_ADDR, false, true);
+    await redeploy('TrailingStopTrigger', REGISTRY_ADDR, true);
 
     if (sender) {
         senderAcc = await hre.ethers.provider.getSigner(sender.toString());
@@ -688,7 +688,7 @@ const mcdBoostRepaySub = async ({
         if (await registry.isRegistered(hre.ethers.utils.id('McdSubProxy').slice(0, 10)).then((e) => !e)) {
             const repayBundleId = await createRepayBundle(proxy, true);
             const boostBundleId = await createBoostBundle(proxy, true);
-            await redeploy('McdSubProxy', REGISTRY_ADDR, false, true, repayBundleId, boostBundleId);
+            await redeploy('McdSubProxy', REGISTRY_ADDR, true, repayBundleId, boostBundleId);
             console.log({ repayBundleId, boostBundleId });
         }
     }
@@ -771,10 +771,10 @@ const aaveAutomationSub = async ({
                 proxy,
                 [boostId1, boostId2],
             );
-            await redeploy('AaveSubProxy', REGISTRY_ADDR, false, true, repayBundleId, boostBundleId);
+            await redeploy('AaveSubProxy', REGISTRY_ADDR, true, repayBundleId, boostBundleId);
             console.log({ repayBundleId, boostBundleId });
 
-            await redeploy('AaveV2RatioCheck', REGISTRY_ADDR, false, true);
+            await redeploy('AaveV2RatioCheck', REGISTRY_ADDR, true);
         }
     }
 
@@ -836,11 +836,11 @@ const compAutomationSub = async ({
                 proxy,
                 [boostId1, boostId2],
             );
-            await redeploy('CompSubProxy', REGISTRY_ADDR, false, true, repayBundleId, boostBundleId);
+            await redeploy('CompSubProxy', REGISTRY_ADDR, true, repayBundleId, boostBundleId);
             console.log({ repayBundleId, boostBundleId });
 
-            await redeploy('CompV2RatioCheck', REGISTRY_ADDR, false, true);
-            await redeploy('CompoundRatioTrigger', REGISTRY_ADDR, false, true);
+            await redeploy('CompV2RatioCheck', REGISTRY_ADDR, true);
+            await redeploy('CompoundRatioTrigger', REGISTRY_ADDR, true);
         }
     }
 
@@ -860,7 +860,7 @@ const compAutomationSub = async ({
 const liquityTrailingCloseToCollStrategySub = async (percentage, sender) => {
     let senderAcc = (await hre.ethers.getSigners())[0];
 
-    await redeploy('TrailingStopTrigger', REGISTRY_ADDR, false, true);
+    await redeploy('TrailingStopTrigger', REGISTRY_ADDR, true);
 
     if (sender) {
         senderAcc = await hre.ethers.provider.getSigner(sender.toString());
@@ -1089,7 +1089,7 @@ const createLiquityTrove = async (coll, debt, sender) => {
 
     setNetwork(network);
 
-    await redeploy('LiquityView', REGISTRY_ADDR, false, true);
+    await redeploy('LiquityView', REGISTRY_ADDR, true);
 
     let proxy = await getProxy(senderAcc.address);
     proxy = sender ? proxy.connect(senderAcc) : proxy;
@@ -1736,8 +1736,8 @@ const subAaveV3MainnetAutomation = async (
 
     // await createBundle(proxy, [strategyId11, strategyId22]);
 
-    await redeploy('AaveV3RatioTrigger', addrs[network].REGISTRY_ADDR, false, true);
-    await redeploy('AaveV3RatioCheck', addrs[network].REGISTRY_ADDR, false, true);
+    await redeploy('AaveV3RatioTrigger', addrs[network].REGISTRY_ADDR, true);
+    await redeploy('AaveV3RatioCheck', addrs[network].REGISTRY_ADDR, true);
 
     // same as in L1
     const subIds = await subAaveV3L2AutomationStrategy(
@@ -2107,7 +2107,7 @@ const subCompV3Automation = async (
 
         // redeploy CompV3SubProxy with new bundles
         await redeploy(
-            'CompV3SubProxy', addrs[network].REGISTRY_ADDR, false, true, repayBundleId, boostBundleId, repayBundleEOAId, boostBundleEOAId,
+            'CompV3SubProxy', addrs[network].REGISTRY_ADDR, true, repayBundleId, boostBundleId, repayBundleEOAId, boostBundleEOAId,
         );
     }
 
@@ -2167,13 +2167,13 @@ const subLimitOrder = async (
     await topUp(addrs[network].OWNER_ACC);
 
     // deploy contracts and strategy
-    await redeploy('OffchainPriceTrigger', addrs[network].REGISTRY_ADDR, false, true);
+    await redeploy('OffchainPriceTrigger', addrs[network].REGISTRY_ADDR, true);
 
     console.log(network);
     // eslint-disable-next-line no-unused-expressions
     network === 'mainnet'
-        ? (await redeploy('LimitSell', addrs[network].REGISTRY_ADDR, false, true))
-        : (await redeploy('LimitSellL2', addrs[network].REGISTRY_ADDR, false, true));
+        ? (await redeploy('LimitSell', addrs[network].REGISTRY_ADDR, true))
+        : (await redeploy('LimitSellL2', addrs[network].REGISTRY_ADDR, true));
 
     // eslint-disable-next-line max-len
     // const strategyData = network === 'mainnet' ? createLimitOrderStrategy() : createLimitOrderL2Strategy();
@@ -2185,7 +2185,7 @@ const subLimitOrder = async (
         strategyId = '9';
     }
 
-    await redeploy('LimitOrderSubProxy', addrs[network].REGISTRY_ADDR, false, true, strategyId);
+    await redeploy('LimitOrderSubProxy', addrs[network].REGISTRY_ADDR, true, strategyId);
 
     // format sub data
     const srcToken = getAssetInfo(srcTokenLabel);
@@ -2853,7 +2853,7 @@ const dcaStrategySub = async (srcTokenLabel, destTokenLabel, amount, interval, s
 
     // const strategyData = network === 'mainnet' ? createDCAStrategy() : createDCAL2Strategy();
     // await openStrategyAndBundleStorage(true);
-    await redeploy('TimestampTrigger', addrs[network].REGISTRY_ADDR, false, true);
+    await redeploy('TimestampTrigger', addrs[network].REGISTRY_ADDR, true);
 
     const srcToken = getAssetInfo(srcTokenLabel);
     const destToken = getAssetInfo(destTokenLabel);
@@ -3877,7 +3877,7 @@ const llammaSell = async (controllerAddress, swapAmount, sellCrvUsd, sender) => 
             if (process.env.TEST_CHAIN_ID) {
                 network = process.env.TEST_CHAIN_ID;
             }
-            await redeploy(contractName.toString(), addrs[network].REGISTRY_ADDR, false, true);
+            await redeploy(contractName.toString(), addrs[network].REGISTRY_ADDR, true);
 
             process.exit(0);
         });
@@ -3910,7 +3910,7 @@ const llammaSell = async (controllerAddress, swapAmount, sellCrvUsd, sender) => 
                 'SparkQuotePriceTrigger',
             ];
 
-            const deployments = await sparkContracts.reduce(async (acc, name) => ({ ...(await acc), [name]: await redeploy(name, addrs[network].REGISTRY_ADDR, false, true).then((c) => c.address) }), {});
+            const deployments = await sparkContracts.reduce(async (acc, name) => ({ ...(await acc), [name]: await redeploy(name, addrs[network].REGISTRY_ADDR, true).then((c) => c.address) }), {});
             console.log(deployments);
 
             process.exit(0);
@@ -3931,7 +3931,7 @@ const llammaSell = async (controllerAddress, swapAmount, sellCrvUsd, sender) => 
                 'McdView',
             ];
 
-            const deployments = await contractsToDeploy.reduce(async (acc, name) => ({ ...(await acc), [name]: await redeploy(name, addrs[network].REGISTRY_ADDR, false, true).then((c) => c.address) }), {});
+            const deployments = await contractsToDeploy.reduce(async (acc, name) => ({ ...(await acc), [name]: await redeploy(name, addrs[network].REGISTRY_ADDR, true).then((c) => c.address) }), {});
             console.log(deployments);
 
             const latestStrategyId = await getLatestStrategyId();

--- a/cmd/forkooor.js
+++ b/cmd/forkooor.js
@@ -2,6 +2,30 @@
 /* eslint-disable no-shadow */
 /* eslint-disable no-use-before-define */
 /* eslint-disable import/no-extraneous-dependencies */
+/*
+ *
+ *
+ *
+ *
+ *
+ *
+ _______   _______ .______   .______       _______   ______     ___   .___________. _______  _______
+|       \ |   ____||   _  \  |   _  \     |   ____| /      |   /   \  |           ||   ____||       \
+|  .--.  ||  |__   |  |_)  | |  |_)  |    |  |__   |  ,----'  /  ^  \ `---|  |----`|  |__   |  .--.  |
+|  |  |  ||   __|  |   ___/  |      /     |   __|  |  |      /  /_\  \    |  |     |   __|  |  |  |  |
+|  '--'  ||  |____ |  |      |  |\  \----.|  |____ |  `----./  _____  \   |  |     |  |____ |  '--'  |
+|_______/ |_______|| _|      | _| `._____||_______| \______/__/     \__\  |__|     |_______||_______/
+
+USE: https://github.com/defisaver/defisaver-forkooor
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ */
+
 const path = require('path');
 const fs = require('fs');
 const { spawnSync } = require('child_process');
@@ -215,7 +239,7 @@ const forkSetup = async (sender) => {
 
     setNetwork(network);
 
-    let proxy = await getProxy(senderAcc.address,);
+    let proxy = await getProxy(senderAcc.address);
     proxy = sender ? proxy.connect(senderAcc) : proxy;
 
     console.log({ sender: senderAcc.address, proxy: proxy.address });
@@ -532,7 +556,7 @@ const liqCBPaybackSub = async (sourceId, sourceType, triggerRatio, triggerState,
         // eslint-disable-next-line no-underscore-dangle
         senderAcc.address = senderAcc._address;
     }
-    let proxy = await getProxy(senderAcc.address,);
+    let proxy = await getProxy(senderAcc.address);
     proxy = sender ? proxy.connect(senderAcc) : proxy;
 
     const { subId } = await subLiquityCBPaybackStrategy(
@@ -553,7 +577,7 @@ const mcdTrailingCloseStrategySub = async (vaultId, type, percentage, isToDai, s
         senderAcc.address = senderAcc._address;
     }
 
-    let proxy = await getProxy(senderAcc.address,);
+    let proxy = await getProxy(senderAcc.address);
     proxy = sender ? proxy.connect(senderAcc) : proxy;
 
     const ilkObj = ilks.find((i) => i.ilkLabel === type);
@@ -613,7 +637,7 @@ const mcdCloseToCollStrategySub = async (vaultId, type, price, priceState, sende
         senderAcc.address = senderAcc._address;
     }
 
-    let proxy = await getProxy(senderAcc.address,);
+    let proxy = await getProxy(senderAcc.address);
     proxy = sender ? proxy.connect(senderAcc) : proxy;
 
     await openStrategyAndBundleStorage(true);
@@ -656,7 +680,7 @@ const mcdBoostRepaySub = async ({
         senderAcc.address = senderAcc._address;
     }
 
-    let proxy = await getProxy(senderAcc.address,);
+    let proxy = await getProxy(senderAcc.address);
     proxy = senderAddr ? proxy.connect(senderAcc) : proxy;
 
     { // deploy if not live
@@ -718,7 +742,7 @@ const aaveAutomationSub = async ({
         senderAcc.address = senderAcc._address;
     }
 
-    let proxy = await getProxy(senderAcc.address,);
+    let proxy = await getProxy(senderAcc.address);
     proxy = senderAddr ? proxy.connect(senderAcc) : proxy;
 
     { // deploy if not live
@@ -783,7 +807,7 @@ const compAutomationSub = async ({
         senderAcc.address = senderAcc._address;
     }
 
-    let proxy = await getProxy(senderAcc.address,);
+    let proxy = await getProxy(senderAcc.address);
     proxy = senderAddr ? proxy.connect(senderAcc) : proxy;
 
     { // deploy if not live
@@ -844,7 +868,7 @@ const liquityTrailingCloseToCollStrategySub = async (percentage, sender) => {
         senderAcc.address = senderAcc._address;
     }
 
-    let proxy = await getProxy(senderAcc.address,);
+    let proxy = await getProxy(senderAcc.address);
     proxy = sender ? proxy.connect(senderAcc) : proxy;
 
     // grab latest roundId from chainlink
@@ -874,7 +898,7 @@ const liquityCloseToCollStrategySub = async (price, priceState, sender) => {
         senderAcc.address = senderAcc._address;
     }
 
-    let proxy = await getProxy(senderAcc.address,);
+    let proxy = await getProxy(senderAcc.address);
     proxy = sender ? proxy.connect(senderAcc) : proxy;
 
     await openStrategyAndBundleStorage(true);
@@ -915,7 +939,7 @@ const updateSmartSavingsStrategySub = async (protocol, subId, vaultId, minRatio,
         senderAcc.address = senderAcc._address;
     }
 
-    let proxy = await getProxy(senderAcc.address,);
+    let proxy = await getProxy(senderAcc.address);
     proxy = sender ? proxy.connect(senderAcc) : proxy;
 
     const subProxyAddr = await getAddrFromRegistry('SubProxy', REGISTRY_ADDR);
@@ -974,7 +998,7 @@ const activateSub = async (subId, sender) => {
         senderAcc.address = senderAcc._address;
     }
 
-    let proxy = await getProxy(senderAcc.address,);
+    let proxy = await getProxy(senderAcc.address);
     proxy = sender ? proxy.connect(senderAcc) : proxy;
 
     const subProxyAddr = await getAddrFromRegistry('SubProxy', REGISTRY_ADDR);
@@ -1012,7 +1036,7 @@ const deactivateSub = async (subId, sender) => {
         senderAcc.address = senderAcc._address;
     }
 
-    let proxy = await getProxy(senderAcc.address,);
+    let proxy = await getProxy(senderAcc.address);
     proxy = sender ? proxy.connect(senderAcc) : proxy;
 
     const subProxyAddr = '0xd18d4756bbf848674cc35f1a0b86afef20787382';
@@ -1067,7 +1091,7 @@ const createLiquityTrove = async (coll, debt, sender) => {
 
     await redeploy('LiquityView', REGISTRY_ADDR, false, true);
 
-    let proxy = await getProxy(senderAcc.address,);
+    let proxy = await getProxy(senderAcc.address);
     proxy = sender ? proxy.connect(senderAcc) : proxy;
 
     const amountColl = hre.ethers.utils.parseUnits(coll, 18);
@@ -1121,7 +1145,7 @@ const createMcdVault = async (type, coll, debt, sender) => {
 
     await topUp(senderAcc.address);
 
-    let proxy = await getProxy(senderAcc.address,);
+    let proxy = await getProxy(senderAcc.address);
     proxy = sender ? proxy.connect(senderAcc) : proxy;
 
     const ilkObj = ilks.find((i) => i.ilkLabel === type);
@@ -1191,7 +1215,7 @@ const createCB = async (lusdAmount, sender) => {
 
     await topUp(senderAcc.address);
 
-    let proxy = await getProxy(senderAcc.address,);
+    let proxy = await getProxy(senderAcc.address);
     proxy = sender ? proxy.connect(senderAcc) : proxy;
 
     let network = 'mainnet';
@@ -1260,7 +1284,7 @@ const getTrove = async (acc) => {
     if (!acc) {
         const senderAcc = (await hre.ethers.getSigners())[0];
 
-        const proxy = await getProxy(senderAcc.address,);
+        const proxy = await getProxy(senderAcc.address);
         // eslint-disable-next-line no-param-reassign
         acc = proxy.address;
     }
@@ -1287,7 +1311,7 @@ const callSell = async (srcTokenLabel, destTokenLabel, srcAmount, sender) => {
     }
 
     await topUp(senderAcc.address);
-    let proxy = await getProxy(senderAcc.address,);
+    let proxy = await getProxy(senderAcc.address);
     proxy = sender ? proxy.connect(senderAcc) : proxy;
 
     try {
@@ -1328,7 +1352,7 @@ const supplyCdp = async (type, cdpId, amount, sender) => {
     }
 
     await topUp(senderAcc.address);
-    let proxy = await getProxy(senderAcc.address,);
+    let proxy = await getProxy(senderAcc.address);
     proxy = sender ? proxy.connect(senderAcc) : proxy;
 
     const ilkObj = ilks.find((i) => i.ilkLabel === type);
@@ -1372,7 +1396,7 @@ const withdrawLiquity = async (collAmount, sender) => {
     await topUp(senderAcc.address);
     await redeploy('LiquityView');
 
-    let proxy = await getProxy(senderAcc.address,);
+    let proxy = await getProxy(senderAcc.address);
     proxy = sender ? proxy.connect(senderAcc) : proxy;
 
     const collAmountWei = hre.ethers.utils.parseUnits(collAmount, 18);
@@ -1409,7 +1433,7 @@ const withdrawCdp = async (type, cdpId, amount, sender) => {
 
     await topUp(senderAcc.address);
 
-    let proxy = await getProxy(senderAcc.address,);
+    let proxy = await getProxy(senderAcc.address);
     proxy = sender ? proxy.connect(senderAcc) : proxy;
 
     const ilkObj = ilks.find((i) => i.ilkLabel === type);
@@ -1467,7 +1491,7 @@ const createAavePosition = async (collSymbol, debtSymbol, collAmount, debtAmount
     const { address: collAddr, ...collAssetInfo } = getAssetInfo(collSymbol, chainIds[network]);
     const { address: debtAddr, ...debtAssetInfo } = getAssetInfo(debtSymbol, chainIds[network]);
 
-    let proxy = await getProxy(senderAcc.address,);
+    let proxy = await getProxy(senderAcc.address);
     proxy = sender ? proxy.connect(senderAcc) : proxy;
 
     const aaveMarketContract = await hre.ethers.getContractAt('IPoolAddressesProvider', addrs[network].AAVE_MARKET);
@@ -1642,7 +1666,7 @@ const subAaveAutomation = async (
     setNetwork(network);
     await topUp(getOwnerAddr());
 
-    let proxy = await getProxy(senderAcc.address,);
+    let proxy = await getProxy(senderAcc.address);
     proxy = sender ? proxy.connect(senderAcc) : proxy;
 
     const subIds = await subAaveV3L2AutomationStrategy(
@@ -1692,7 +1716,7 @@ const subAaveV3MainnetAutomation = async (
     setNetwork(network);
     await topUp(getOwnerAddr());
 
-    let proxy = await getProxy(senderAcc.address,);
+    let proxy = await getProxy(senderAcc.address);
     proxy = sender ? proxy.connect(senderAcc) : proxy;
 
     // await openStrategyAndBundleStorage(true);
@@ -1758,7 +1782,7 @@ const subAaveClose = async (
         // eslint-disable-next-line no-underscore-dangle
         senderAcc.address = senderAcc._address;
     }
-    proxy = await getProxy(senderAcc.address,);
+    proxy = await getProxy(senderAcc.address);
     proxy = sender ? proxy.connect(senderAcc) : proxy;
 
     await topUp(getOwnerAddr());
@@ -1839,7 +1863,7 @@ const subAaveCloseWithMaximumGasPrice = async (
         // eslint-disable-next-line no-underscore-dangle
         senderAcc.address = senderAcc._address;
     }
-    proxy = await getProxy(senderAcc.address,);
+    proxy = await getProxy(senderAcc.address);
     proxy = sender ? proxy.connect(senderAcc) : proxy;
 
     await topUp(getOwnerAddr());
@@ -1927,7 +1951,7 @@ const subSparkAutomation = async (
     setNetwork(network);
     await topUp(getOwnerAddr());
 
-    let proxy = await getProxy(senderAcc.address,);
+    let proxy = await getProxy(senderAcc.address);
     proxy = sender ? proxy.connect(senderAcc) : proxy;
 
     if (await getLatestBundleId() < 18) {
@@ -1982,7 +2006,7 @@ const subSparkClose = async (
         // eslint-disable-next-line no-underscore-dangle
         senderAcc.address = senderAcc._address;
     }
-    proxy = await getProxy(senderAcc.address,);
+    proxy = await getProxy(senderAcc.address);
     proxy = sender ? proxy.connect(senderAcc) : proxy;
 
     await topUp(getOwnerAddr());
@@ -2061,7 +2085,7 @@ const subCompV3Automation = async (
 
     setNetwork(network);
 
-    let proxy = await getProxy(senderAcc.address,);
+    let proxy = await getProxy(senderAcc.address);
     proxy = sender ? proxy.connect(senderAcc) : proxy;
 
     const bundleId = await getLatestBundleId();
@@ -2137,7 +2161,7 @@ const subLimitOrder = async (
     setNetwork(network);
     set('network', chainIds[network]);
 
-    let proxy = await getProxy(senderAcc.address,);
+    let proxy = await getProxy(senderAcc.address);
     proxy = sender ? proxy.connect(senderAcc) : proxy;
 
     await topUp(addrs[network].OWNER_ACC);
@@ -2498,7 +2522,7 @@ const getAavePos = async (
 
     setNetwork(network);
 
-    let proxy = await getProxy(senderAcc.address,);
+    let proxy = await getProxy(senderAcc.address);
     proxy = sender ? proxy.connect(senderAcc) : proxy;
 
     const aaveView = await hre.ethers.getContractAt('AaveV3View', addrs[network].AAVE_V3_VIEW);
@@ -2567,7 +2591,7 @@ const getCompV3Pos = async (
 
     setNetwork(network);
 
-    let proxy = await getProxy(senderAcc.address,);
+    let proxy = await getProxy(senderAcc.address);
     proxy = sender ? proxy.connect(senderAcc) : proxy;
 
     const compV3View = await hre.ethers.getContractAt('CompV3View', '0x5e07E953dac1d7c19091c3b493579ba7283572a4');
@@ -2622,7 +2646,7 @@ const updateAaveV3AutomationSub = async (
 
     setNetwork(network);
 
-    let proxy = await getProxy(senderAcc.address,);
+    let proxy = await getProxy(senderAcc.address);
     proxy = sender ? proxy.connect(senderAcc) : proxy;
 
     await openStrategyAndBundleStorage(true);
@@ -2730,7 +2754,7 @@ const createCompV3Position = async (
     const collAmountWei = hre.ethers.utils.parseUnits(collAmount, collToken.decimals);
     const debtAmountWei = hre.ethers.utils.parseUnits(debtAmount, 6);
 
-    let proxy = await getProxy(senderAcc.address,);
+    let proxy = await getProxy(senderAcc.address);
     proxy = sender ? proxy.connect(senderAcc) : proxy;
 
     console.log(proxy.address);
@@ -2824,7 +2848,7 @@ const dcaStrategySub = async (srcTokenLabel, destTokenLabel, amount, interval, s
     set('network', chainIds[network]);
     setNetwork(network);
 
-    let proxy = await getProxy(senderAcc.address,);
+    let proxy = await getProxy(senderAcc.address);
     proxy = sender ? proxy.connect(senderAcc) : proxy;
 
     // const strategyData = network === 'mainnet' ? createDCAStrategy() : createDCAL2Strategy();

--- a/cmd/forkooor.js
+++ b/cmd/forkooor.js
@@ -1560,21 +1560,21 @@ const createAavePosition = async (collSymbol, debtSymbol, collAmount, debtAmount
 };
 
 const deployMorphoContracts = async () => {
-    await getContractFromRegistry('MorphoAaveV2Supply', undefined, false, true);
-    await getContractFromRegistry('MorphoAaveV2Borrow', undefined, false, true);
-    await getContractFromRegistry('MorphoAaveV2Withdraw', undefined, false, true);
-    await getContractFromRegistry('MorphoAaveV2Payback', undefined, false, true);
-    await getContractFromRegistry('MorphoClaim', undefined, false, true);
-    await getContractFromRegistry('MorphoAaveV2View', undefined, false, true);
-    await getContractFromRegistry('MorphoAaveV2RatioTrigger', undefined, false, true);
-    await getContractFromRegistry('MorphoAaveV2RatioCheck', undefined, false, true);
+    await getContractFromRegistry('MorphoAaveV2Supply', undefined, true);
+    await getContractFromRegistry('MorphoAaveV2Borrow', undefined, true);
+    await getContractFromRegistry('MorphoAaveV2Withdraw', undefined, true);
+    await getContractFromRegistry('MorphoAaveV2Payback', undefined, true);
+    await getContractFromRegistry('MorphoClaim', undefined, true);
+    await getContractFromRegistry('MorphoAaveV2View', undefined, true);
+    await getContractFromRegistry('MorphoAaveV2RatioTrigger', undefined, true);
+    await getContractFromRegistry('MorphoAaveV2RatioCheck', undefined, true);
 };
 
 const createMorphoPosition = async (collSymbol, debtSymbol, collAmount, debtAmount, sender) => {
     const { senderAcc, proxy, network } = await forkSetup(sender);
 
     await deployMorphoContracts();
-    const view = await getContractFromRegistry('MorphoAaveV2View', undefined, false, true);
+    const view = await getContractFromRegistry('MorphoAaveV2View', undefined, true);
 
     const { address: collAddr, ...collAssetInfo } = getAssetInfo(collSymbol, chainIds[network]);
     const { address: debtAddr, ...debtAssetInfo } = getAssetInfo(debtSymbol, chainIds[network]);
@@ -2260,7 +2260,7 @@ const subMorphoAaveV2Automation = async (
 
         await deployMorphoContracts();
         await getContractFromRegistry(
-            'MorphoAaveV2SubProxy', undefined, undefined, true, repayBundleId, boostBundleId,
+            'MorphoAaveV2SubProxy', undefined, true, repayBundleId, boostBundleId,
         );
     }
 
@@ -2380,13 +2380,13 @@ const updateSubDataCompV2 = async (
 };
 
 const deployLiquityContracts = async () => {
-    await getContractFromRegistry('LiquityRatioTrigger', undefined, undefined, true).then(({ address }) => {
+    await getContractFromRegistry('LiquityRatioTrigger', undefined, true).then(({ address }) => {
         if (compare(address, '0x7dDA9F944c3Daf27fbe3B8f27EC5f14FE3fa94BF')) {
             return redeploy('LiquityRatioTrigger', undefined, undefined, true);
         }
         return address;
     });
-    await getContractFromRegistry('LiquityRatioCheck', undefined, undefined, true);
+    await getContractFromRegistry('LiquityRatioCheck', undefined, true);
 };
 
 const liqDebtInFrontRepaySub = async (
@@ -2444,7 +2444,7 @@ const subLiquityAutomation = async (
 
         await deployLiquityContracts();
         await getContractFromRegistry(
-            'LiquitySubProxy', undefined, undefined, true, repayBundleId, boostBundleId,
+            'LiquitySubProxy', undefined, true, repayBundleId, boostBundleId,
         );
     }
 
@@ -3829,7 +3829,7 @@ const llammaSell = async (controllerAddress, swapAmount, sellCrvUsd, sender) => 
         .description('MorphoAaveV2 position view, default to proxy')
         .action(async (isEOA, addr) => {
             const { senderAcc, proxy } = await forkSetup(addr);
-            const view = await getContractFromRegistry('MorphoAaveV2View', undefined, false, true);
+            const view = await getContractFromRegistry('MorphoAaveV2View', undefined, true);
 
             const user = compare(isEOA, 'false') ? proxy.address : senderAcc.address;
             console.log(`Fetching position for ${user}`);

--- a/cmd/tenderly-cli.js
+++ b/cmd/tenderly-cli.js
@@ -5,6 +5,7 @@ const fs = require('fs');
 const path = require('path');
 const axios = require('axios');
 const { program } = require('commander');
+const { createFork, topUp } = require('../scripts/utils/fork');
 
 const supportedNetworks = {
     mainnet: '1',
@@ -187,6 +188,28 @@ const syncAll = async (options) => {
         .description('Add all missing contracts to tenderly project')
         .action(async (options) => {
             await syncAll(options);
+            process.exit(0);
+        });
+
+    program
+        .command('createFork')
+        .option('-n, --network <network>', 'Specify network (defaults to mainnet)', [])
+        .description('Creates a new tenderly vnet fork')
+        .action(async (options) => {
+            const network = options.network.length === 0 ? 'mainnet' : options.network;
+            const rpcUrl = await createFork(network);
+            console.log(`Rpc url: ${rpcUrl}`);
+            process.exit(0);
+        });
+
+    program
+        .command('gibMoney <account>')
+        .option('-n, --network <network>', 'Specify network (defaults to mainnet)', [])
+        .description('Gives 1000 Eth to account on vnet')
+        .action(async (account, options) => {
+            const network = options.network.length === 0 ? 'mainnet' : options.network;
+            await topUp(account, network);
+            console.log(`Acc: ${account} credited with 1000 Eth on ${network} vnet`);
             process.exit(0);
         });
 

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -34,7 +34,6 @@ const testNetworks = Object.fromEntries([...Array(MAX_NODE_COUNT).keys()].map((c
  * @type import('hardhat/config').HardhatUserConfig
  */
 module.exports = {
-    saveOnTenderly: false,
     defaultNetwork: 'fork',
     lightTesting: true,
     isWalletSafe: true,

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -6,6 +6,7 @@ require('@nomiclabs/hardhat-ethers');
 require('hardhat-gas-reporter');
 require('hardhat-log-remover');
 require('hardhat-tracer');
+require('@tenderly/hardhat-tenderly');
 
 const Dec = require('decimal.js');
 const dfs = require('@defisaver/sdk');
@@ -79,7 +80,7 @@ module.exports = {
             chainId: 1,
         },
         fork: {
-            url: `https://rpc.tenderly.co/fork/${process.env.FORK_ID}`,
+            url: `https://virtual.mainnet.rpc.tenderly.co/${process.env.FORK_ID}`,
             timeout: 1000000,
             type: 'tenderly',
             name: 'mainnet',

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@nomicfoundation/hardhat-verify": "^2.0.11",
     "@nomiclabs/hardhat-ethers": "^2.2.3",
     "@nomiclabs/hardhat-waffle": "^2.0.0",
-    "@tenderly/hardhat-tenderly": "^1.3.2",
+    "@tenderly/hardhat-tenderly": "^1.8.0",
     "@uniswap/sdk-core": "^3.1.1",
     "@uniswap/smart-order-router": "^3.5.0",
     "axios": "^0.28.0",

--- a/scripts/deploy-aaveV3.js
+++ b/scripts/deploy-aaveV3.js
@@ -11,17 +11,17 @@ async function main() {
     const senderAcc = (await hre.ethers.getSigners())[0];
     await topUp(senderAcc.address);
 
-    const aaveV3ATokenPayback = await redeploy('AaveV3ATokenPayback', addrs[network].REGISTRY_ADDR, true, true);
-    const aaveV3Borrow = await redeploy('AaveV3Borrow', addrs[network].REGISTRY_ADDR, true, true);
-    const aaveV3ClaimRewards = await redeploy('AaveV3ClaimRewards', addrs[network].REGISTRY_ADDR, true, true);
-    const aaveV3CollateralSwitch = await redeploy('AaveV3CollateralSwitch', addrs[network].REGISTRY_ADDR, true, true);
-    const aaveV3Payback = await redeploy('AaveV3Payback', addrs[network].REGISTRY_ADDR, true, true);
-    const aaveV3SetEMode = await redeploy('AaveV3SetEMode', addrs[network].REGISTRY_ADDR, true, true);
-    const aaveV3Supply = await redeploy('AaveV3Supply', addrs[network].REGISTRY_ADDR, true, true);
-    const aaveV3SwapBorrowRateMode = await redeploy('AaveV3SwapBorrowRateMode', addrs[network].REGISTRY_ADDR, true, true);
-    const aaveV3Withdraw = await redeploy('AaveV3Withdraw', addrs[network].REGISTRY_ADDR, true, true);
-    const aaveV3View = await redeploy('AaveV3View', addrs[network].REGISTRY_ADDR, true, true);
-    const aaveFL = await redeploy('FLAaveV3', addrs[network].REGISTRY_ADDR, true, true);
+    const aaveV3ATokenPayback = await redeploy('AaveV3ATokenPayback', addrs[network].REGISTRY_ADDR, true);
+    const aaveV3Borrow = await redeploy('AaveV3Borrow', addrs[network].REGISTRY_ADDR, true);
+    const aaveV3ClaimRewards = await redeploy('AaveV3ClaimRewards', addrs[network].REGISTRY_ADDR, true);
+    const aaveV3CollateralSwitch = await redeploy('AaveV3CollateralSwitch', addrs[network].REGISTRY_ADDR, true);
+    const aaveV3Payback = await redeploy('AaveV3Payback', addrs[network].REGISTRY_ADDR, true);
+    const aaveV3SetEMode = await redeploy('AaveV3SetEMode', addrs[network].REGISTRY_ADDR, true);
+    const aaveV3Supply = await redeploy('AaveV3Supply', addrs[network].REGISTRY_ADDR, true);
+    const aaveV3SwapBorrowRateMode = await redeploy('AaveV3SwapBorrowRateMode', addrs[network].REGISTRY_ADDR, true);
+    const aaveV3Withdraw = await redeploy('AaveV3Withdraw', addrs[network].REGISTRY_ADDR, true);
+    const aaveV3View = await redeploy('AaveV3View', addrs[network].REGISTRY_ADDR, true);
+    const aaveFL = await redeploy('FLAaveV3', addrs[network].REGISTRY_ADDR, true);
 
     console.log(`AaveV3ATokenPayback: ${aaveV3ATokenPayback.address}`);
     console.log(`AaveV3Borrow: ${aaveV3Borrow.address}`);

--- a/scripts/deploy-apy-after-values.js
+++ b/scripts/deploy-apy-after-values.js
@@ -16,22 +16,22 @@ async function main() {
     await topUp(senderAcc.address);
     await topUp(getOwnerAddr());
 
-    const compV2View = await redeploy('CompView', addrs[network].REGISTRY_ADDR, false, true);
+    const compV2View = await redeploy('CompView', addrs[network].REGISTRY_ADDR, true);
     console.log('CompView deployed to:', compV2View.address);
 
-    const compV3View = await redeploy('CompV3View', addrs[network].REGISTRY_ADDR, false, true);
+    const compV3View = await redeploy('CompV3View', addrs[network].REGISTRY_ADDR, true);
     console.log('CompV3View deployed to:', compV3View.address);
 
-    const aaveV2View = await redeploy('AaveView', addrs[network].REGISTRY_ADDR, false, true);
+    const aaveV2View = await redeploy('AaveView', addrs[network].REGISTRY_ADDR, true);
     console.log('AaveView deployed to:', aaveV2View.address);
 
-    const aaveV3View = await redeploy('AaveV3View', addrs[network].REGISTRY_ADDR, false, true);
+    const aaveV3View = await redeploy('AaveV3View', addrs[network].REGISTRY_ADDR, true);
     console.log('AaveV3View deployed to:', aaveV3View.address);
 
-    const sparkView = await redeploy('SparkView', addrs[network].REGISTRY_ADDR, false, true);
+    const sparkView = await redeploy('SparkView', addrs[network].REGISTRY_ADDR, true);
     console.log('SparkView deployed to:', sparkView.address);
 
-    const morphoView = await redeploy('MorphoBlueView', addrs[network].REGISTRY_ADDR, false, true);
+    const morphoView = await redeploy('MorphoBlueView', addrs[network].REGISTRY_ADDR, true);
     console.log('MorphoBlueView deployed to:', morphoView.address);
 
     process.exit(0);

--- a/scripts/deploy-chicken-bonds.js
+++ b/scripts/deploy-chicken-bonds.js
@@ -11,13 +11,13 @@ async function main() {
     const senderAcc = (await hre.ethers.getSigners())[0];
     await topUp(senderAcc.address);
 
-    const chickenBondsView = await redeploy('ChickenBondsView', addrs[network].REGISTRY_ADDR, true, true);
+    const chickenBondsView = await redeploy('ChickenBondsView', addrs[network].REGISTRY_ADDR, true);
 
-    const cbChickenIn = await redeploy('CBChickenIn', addrs[network].REGISTRY_ADDR, true, true);
-    const cbChickenOut = await redeploy('CBChickenOut', addrs[network].REGISTRY_ADDR, true, true);
-    const cbCreate = await redeploy('CBCreate', addrs[network].REGISTRY_ADDR, true, true);
-    const cbRedeem = await redeploy('CBRedeem', addrs[network].REGISTRY_ADDR, true, true);
-    const transferNFT = await redeploy('TransferNFT', addrs[network].REGISTRY_ADDR, true, true);
+    const cbChickenIn = await redeploy('CBChickenIn', addrs[network].REGISTRY_ADDR, true);
+    const cbChickenOut = await redeploy('CBChickenOut', addrs[network].REGISTRY_ADDR, true);
+    const cbCreate = await redeploy('CBCreate', addrs[network].REGISTRY_ADDR, true);
+    const cbRedeem = await redeploy('CBRedeem', addrs[network].REGISTRY_ADDR, true);
+    const transferNFT = await redeploy('TransferNFT', addrs[network].REGISTRY_ADDR, true);
 
     console.log(`ChickenBondsView: ${chickenBondsView.address}`);
 

--- a/scripts/deploy-compV3-strategies-arb.js
+++ b/scripts/deploy-compV3-strategies-arb.js
@@ -46,10 +46,10 @@ async function main() {
 
     console.log(repayBundleId, boostBundleId);
 
-    await redeploy('CompV3SubProxyL2', addrs[network].REGISTRY_ADDR, true, true, repayBundleId, boostBundleId);
-    await redeploy('CompV3View', addrs[network].REGISTRY_ADDR, true, true);
-    await redeploy('CompV3RatioCheck', addrs[network].REGISTRY_ADDR, true, true);
-    await redeploy('CompV3RatioTrigger', addrs[network].REGISTRY_ADDR, true, true);
+    await redeploy('CompV3SubProxyL2', addrs[network].REGISTRY_ADDR, true, repayBundleId, boostBundleId);
+    await redeploy('CompV3View', addrs[network].REGISTRY_ADDR, true);
+    await redeploy('CompV3RatioCheck', addrs[network].REGISTRY_ADDR, true);
+    await redeploy('CompV3RatioTrigger', addrs[network].REGISTRY_ADDR, true);
 
     process.exit(0);
 }

--- a/scripts/deploy-compV3.js
+++ b/scripts/deploy-compV3.js
@@ -12,7 +12,7 @@ async function main() {
     await topUp(senderAcc.address);
     await topUp(getOwnerAddr());
 
-    const compV3RatioCheck = await redeploy('StarknetClaim', addrs[network].REGISTRY_ADDR, true, true);
+    const compV3RatioCheck = await redeploy('StarknetClaim', addrs[network].REGISTRY_ADDR, true);
     process.exit(0);
 }
 

--- a/scripts/deploy-curveUSD.js
+++ b/scripts/deploy-curveUSD.js
@@ -18,10 +18,10 @@ async function main() {
     const senderAcc = (await hre.ethers.getSigners())[0];
     await topUp(senderAcc.address);
 
-    const curveUsdRepay = await redeploy('CurveUsdRepay', addrs[network].REGISTRY_ADDR, true, true);
-    const curveUsdCollRatioTrigger = await redeploy('CurveUsdCollRatioTrigger', addrs[network].REGISTRY_ADDR, true, true);
-    const curveUsdCollRatioCheck = await redeploy('CurveUsdCollRatioCheck', addrs[network].REGISTRY_ADDR, true, true);
-    const curveUsdSwapper = await redeploy('CurveUsdSwapper', addrs[network].REGISTRY_ADDR, true, true);
+    const curveUsdRepay = await redeploy('CurveUsdRepay', addrs[network].REGISTRY_ADDR, true);
+    const curveUsdCollRatioTrigger = await redeploy('CurveUsdCollRatioTrigger', addrs[network].REGISTRY_ADDR, true);
+    const curveUsdCollRatioCheck = await redeploy('CurveUsdCollRatioCheck', addrs[network].REGISTRY_ADDR, true);
+    const curveUsdSwapper = await redeploy('CurveUsdSwapper', addrs[network].REGISTRY_ADDR, true);
 
     await openStrategyAndBundleStorage(true);
 

--- a/scripts/deploy-curveUSDPayback.js
+++ b/scripts/deploy-curveUSDPayback.js
@@ -17,13 +17,13 @@ async function main() {
     await topUp(senderAcc.address);
     await topUp(getOwnerAddr());
 
-    const recipeExecutor = await redeploy('RecipeExecutor', addrs[network].REGISTRY_ADDR, true, true);
-    const safeModuleAuth = await redeploy('SafeModuleAuth', addrs[network].REGISTRY_ADDR, true, true);
-    const strategyExecutor = await redeploy('StrategyExecutor', addrs[network].REGISTRY_ADDR, true, true);
-    const subProxy = await redeploy('SubProxy', addrs[network].REGISTRY_ADDR, true, true);
+    const recipeExecutor = await redeploy('RecipeExecutor', addrs[network].REGISTRY_ADDR, true);
+    const safeModuleAuth = await redeploy('SafeModuleAuth', addrs[network].REGISTRY_ADDR, true);
+    const strategyExecutor = await redeploy('StrategyExecutor', addrs[network].REGISTRY_ADDR, true);
+    const subProxy = await redeploy('SubProxy', addrs[network].REGISTRY_ADDR, true);
 
-    const curveUsdPayback = await redeploy('CurveUsdPayback', addrs[network].REGISTRY_ADDR, true, true);
-    const curveUsdHealthRatioTrigger = await redeploy('CurveUsdHealthRatioTrigger', addrs[network].REGISTRY_ADDR, true, true);
+    const curveUsdPayback = await redeploy('CurveUsdPayback', addrs[network].REGISTRY_ADDR, true);
+    const curveUsdHealthRatioTrigger = await redeploy('CurveUsdHealthRatioTrigger', addrs[network].REGISTRY_ADDR, true);
 
     await openStrategyAndBundleStorage(true);
 

--- a/scripts/deploy-curveusd-transient-actions.js
+++ b/scripts/deploy-curveusd-transient-actions.js
@@ -10,11 +10,11 @@ async function main() {
     const senderAcc = (await hre.ethers.getSigners())[0];
     await topUp(senderAcc.address);
     await topUp(getOwnerAddr());
-    const curveUsdLevCreateTransient = await redeploy('CurveUsdLevCreateTransient', addrs[network].REGISTRY_ADDR, false, true);
-    const curveUsdRepayTransient = await redeploy('CurveUsdRepayTransient', addrs[network].REGISTRY_ADDR, false, true);
-    const curveUsdSelfLiquidateWithCollTransient = await redeploy('CurveUsdSelfLiquidateWithCollTransient', addrs[network].REGISTRY_ADDR, false, true);
-    const curveUsdSwapperTransient = await redeploy('CurveUsdSwapperTransient', addrs[network].REGISTRY_ADDR, false, true);
-    const flAction = await redeploy('FLAction', addrs[network].REGISTRY_ADDR, false, true);
+    const curveUsdLevCreateTransient = await redeploy('CurveUsdLevCreateTransient', addrs[network].REGISTRY_ADDR, true);
+    const curveUsdRepayTransient = await redeploy('CurveUsdRepayTransient', addrs[network].REGISTRY_ADDR, true);
+    const curveUsdSelfLiquidateWithCollTransient = await redeploy('CurveUsdSelfLiquidateWithCollTransient', addrs[network].REGISTRY_ADDR, true);
+    const curveUsdSwapperTransient = await redeploy('CurveUsdSwapperTransient', addrs[network].REGISTRY_ADDR, true);
+    const flAction = await redeploy('FLAction', addrs[network].REGISTRY_ADDR, true);
     console.log('CurveUsdLevCreateTransient deployed to:', curveUsdLevCreateTransient.address);
     console.log('CurveUsdRepayTransient deployed to:', curveUsdRepayTransient.address);
     console.log('CurveUsdSelfLiquidateWithCollTransient deployed to:', curveUsdSelfLiquidateWithCollTransient.address);

--- a/scripts/deploy-eulerV2.js
+++ b/scripts/deploy-eulerV2.js
@@ -14,11 +14,11 @@ async function main() {
     await topUp(senderAcc.address);
     await topUp(getOwnerAddr());
 
-    const eulerV2Supply = await redeploy('EulerV2Supply', addrs[network].REGISTRY_ADDR, false, true);
-    const eulerV2Withdraw = await redeploy('EulerV2Withdraw', addrs[network].REGISTRY_ADDR, false, true);
-    const eulerV2Borrow = await redeploy('EulerV2Borrow', addrs[network].REGISTRY_ADDR, false, true);
-    const eulerV2Payback = await redeploy('EulerV2Payback', addrs[network].REGISTRY_ADDR, false, true);
-    const eulerV2View = await redeploy('EulerV2View', addrs[network].REGISTRY_ADDR, false, true);
+    const eulerV2Supply = await redeploy('EulerV2Supply', addrs[network].REGISTRY_ADDR, true);
+    const eulerV2Withdraw = await redeploy('EulerV2Withdraw', addrs[network].REGISTRY_ADDR, true);
+    const eulerV2Borrow = await redeploy('EulerV2Borrow', addrs[network].REGISTRY_ADDR, true);
+    const eulerV2Payback = await redeploy('EulerV2Payback', addrs[network].REGISTRY_ADDR, true);
+    const eulerV2View = await redeploy('EulerV2View', addrs[network].REGISTRY_ADDR, true);
 
     console.log(`EulerV2Supply: ${eulerV2Supply.address}`);
     console.log(`EulerV2Withdraw: ${eulerV2Withdraw.address}`);
@@ -27,10 +27,10 @@ async function main() {
     console.log(`EulerV2View: ${eulerV2View.address}`);
 
     if (!ONLY_BASIC) {
-        const eulerV2PaybackWithShares = await redeploy('EulerV2PaybackWithShares', addrs[network].REGISTRY_ADDR, false, true);
-        const eulerV2PullDebt = await redeploy('EulerV2PullDebt', addrs[network].REGISTRY_ADDR, false, true);
-        const eulerV2CollateralSwitch = await redeploy('EulerV2CollateralSwitch', addrs[network].REGISTRY_ADDR, false, true);
-        const eulerV2ReorderCollaterals = await redeploy('EulerV2ReorderCollaterals', addrs[network].REGISTRY_ADDR, false, true);
+        const eulerV2PaybackWithShares = await redeploy('EulerV2PaybackWithShares', addrs[network].REGISTRY_ADDR, true);
+        const eulerV2PullDebt = await redeploy('EulerV2PullDebt', addrs[network].REGISTRY_ADDR, true);
+        const eulerV2CollateralSwitch = await redeploy('EulerV2CollateralSwitch', addrs[network].REGISTRY_ADDR, true);
+        const eulerV2ReorderCollaterals = await redeploy('EulerV2ReorderCollaterals', addrs[network].REGISTRY_ADDR, true);
 
         console.log(`EulerV2PaybackWithShares: ${eulerV2PaybackWithShares.address}`);
         console.log(`EulerV2PullDebt: ${eulerV2PullDebt.address}`);

--- a/scripts/deploy-fluid.js
+++ b/scripts/deploy-fluid.js
@@ -17,15 +17,15 @@ async function main() {
         await topUp(getOwnerAddr());
     }
 
-    const fluidT1Open = await redeploy('FluidVaultT1Open', addrs[network].REGISTRY_ADDR, false, isFork);
-    const fluidT1Supply = await redeploy('FluidVaultT1Supply', addrs[network].REGISTRY_ADDR, false, isFork);
-    const fluidT1Withdraw = await redeploy('FluidVaultT1Withdraw', addrs[network].REGISTRY_ADDR, false, isFork);
-    const fluidT1Borrow = await redeploy('FluidVaultT1Borrow', addrs[network].REGISTRY_ADDR, false, isFork);
-    const fluidT1Payback = await redeploy('FluidVaultT1Payback', addrs[network].REGISTRY_ADDR, false, isFork);
-    const fluidT1Adjust = await redeploy('FluidVaultT1Adjust', addrs[network].REGISTRY_ADDR, false, isFork);
-    const fluidRatioTrigger = await redeploy('FluidRatioTrigger', addrs[network].REGISTRY_ADDR, false, isFork);
-    const fluidRatioChecker = await redeploy('FluidRatioCheck', addrs[network].REGISTRY_ADDR, false, isFork);
-    const view = await redeploy('FluidView', addrs[network].REGISTRY_ADDR, false, isFork);
+    const fluidT1Open = await redeploy('FluidVaultT1Open', addrs[network].REGISTRY_ADDR, isFork);
+    const fluidT1Supply = await redeploy('FluidVaultT1Supply', addrs[network].REGISTRY_ADDR, isFork);
+    const fluidT1Withdraw = await redeploy('FluidVaultT1Withdraw', addrs[network].REGISTRY_ADDR, isFork);
+    const fluidT1Borrow = await redeploy('FluidVaultT1Borrow', addrs[network].REGISTRY_ADDR, isFork);
+    const fluidT1Payback = await redeploy('FluidVaultT1Payback', addrs[network].REGISTRY_ADDR, isFork);
+    const fluidT1Adjust = await redeploy('FluidVaultT1Adjust', addrs[network].REGISTRY_ADDR, isFork);
+    const fluidRatioTrigger = await redeploy('FluidRatioTrigger', addrs[network].REGISTRY_ADDR, isFork);
+    const fluidRatioChecker = await redeploy('FluidRatioCheck', addrs[network].REGISTRY_ADDR, isFork);
+    const view = await redeploy('FluidView', addrs[network].REGISTRY_ADDR, isFork);
 
     console.log(`FluidVaultT1Open: ${fluidT1Open.address}`);
     console.log(`FluidVaultT1Supply: ${fluidT1Supply.address}`);

--- a/scripts/deploy-liquityV2.js
+++ b/scripts/deploy-liquityV2.js
@@ -24,13 +24,13 @@ async function main() {
         await topUp(getOwnerAddr());
     }
 
-    const liquityV2View = await redeploy('LiquityV2View', addrs[network].REGISTRY_ADDR, false, isFork);
-    const liquityV2Open = await redeploy('LiquityV2Open', addrs[network].REGISTRY_ADDR, false, isFork);
-    const liquityV2Close = await redeploy('LiquityV2Close', addrs[network].REGISTRY_ADDR, false, isFork);
-    const liquityV2Supply = await redeploy('LiquityV2Supply', addrs[network].REGISTRY_ADDR, false, isFork);
-    const liquityV2Withdraw = await redeploy('LiquityV2Withdraw', addrs[network].REGISTRY_ADDR, false, isFork);
-    const liquityV2Borrow = await redeploy('LiquityV2Borrow', addrs[network].REGISTRY_ADDR, false, isFork);
-    const liquityV2Payback = await redeploy('LiquityV2Payback', addrs[network].REGISTRY_ADDR, false, isFork);
+    const liquityV2View = await redeploy('LiquityV2View', addrs[network].REGISTRY_ADDR, isFork);
+    const liquityV2Open = await redeploy('LiquityV2Open', addrs[network].REGISTRY_ADDR, isFork);
+    const liquityV2Close = await redeploy('LiquityV2Close', addrs[network].REGISTRY_ADDR, isFork);
+    const liquityV2Supply = await redeploy('LiquityV2Supply', addrs[network].REGISTRY_ADDR, isFork);
+    const liquityV2Withdraw = await redeploy('LiquityV2Withdraw', addrs[network].REGISTRY_ADDR, isFork);
+    const liquityV2Borrow = await redeploy('LiquityV2Borrow', addrs[network].REGISTRY_ADDR, isFork);
+    const liquityV2Payback = await redeploy('LiquityV2Payback', addrs[network].REGISTRY_ADDR, isFork);
     console.log(`LiquityV2View: ${liquityV2View.address}`);
     console.log(`LiquityV2Open: ${liquityV2Open.address}`);
     console.log(`LiquityV2Close: ${liquityV2Close.address}`);
@@ -39,13 +39,13 @@ async function main() {
     console.log(`LiquityV2Borrow: ${liquityV2Borrow.address}`);
     console.log(`LiquityV2Payback: ${liquityV2Payback.address}`);
 
-    const liquityV2Claim = await redeploy('LiquityV2Claim', addrs[network].REGISTRY_ADDR, false, isFork);
-    const liquityV2Adjust = await redeploy('LiquityV2Adjust', addrs[network].REGISTRY_ADDR, false, isFork);
-    const liquityV2AdjustInterestRate = await redeploy('LiquityV2AdjustInterestRate', addrs[network].REGISTRY_ADDR, false, isFork);
-    const liquityV2SPDeposit = await redeploy('LiquityV2SPDeposit', addrs[network].REGISTRY_ADDR, false, isFork);
-    const liquityV2SPWithdraw = await redeploy('LiquityV2SPWithdraw', addrs[network].REGISTRY_ADDR, false, isFork);
-    const liquityV2SPClaimColl = await redeploy('LiquityV2SPClaimColl', addrs[network].REGISTRY_ADDR, false, isFork);
-    const liquityV2AdjustZombieTrove = await redeploy('LiquityV2AdjustZombieTrove', addrs[network].REGISTRY_ADDR, false, isFork);
+    const liquityV2Claim = await redeploy('LiquityV2Claim', addrs[network].REGISTRY_ADDR, isFork);
+    const liquityV2Adjust = await redeploy('LiquityV2Adjust', addrs[network].REGISTRY_ADDR, isFork);
+    const liquityV2AdjustInterestRate = await redeploy('LiquityV2AdjustInterestRate', addrs[network].REGISTRY_ADDR, isFork);
+    const liquityV2SPDeposit = await redeploy('LiquityV2SPDeposit', addrs[network].REGISTRY_ADDR, isFork);
+    const liquityV2SPWithdraw = await redeploy('LiquityV2SPWithdraw', addrs[network].REGISTRY_ADDR, isFork);
+    const liquityV2SPClaimColl = await redeploy('LiquityV2SPClaimColl', addrs[network].REGISTRY_ADDR, isFork);
+    const liquityV2AdjustZombieTrove = await redeploy('LiquityV2AdjustZombieTrove', addrs[network].REGISTRY_ADDR, isFork);
     console.log(`LiquityV2Claim: ${liquityV2Claim.address}`);
     console.log(`LiquityV2Adjust: ${liquityV2Adjust.address}`);
     console.log(`LiquityV2AdjustInterestRate: ${liquityV2AdjustInterestRate.address}`);
@@ -57,12 +57,12 @@ async function main() {
     /* //////////////////////////////////////////////////////////////
                             AUTOMATION
     ////////////////////////////////////////////////////////////// */
-    const liquityV2RatioTrigger = await redeploy('LiquityV2RatioTrigger', addrs[network].REGISTRY_ADDR, false, isFork);
-    const liquityV2RatioCheck = await redeploy('LiquityV2RatioCheck', addrs[network].REGISTRY_ADDR, false, isFork);
-    const closePriceTrigger = await redeploy('ClosePriceTrigger', addrs[network].REGISTRY_ADDR, false, isFork);
-    const liquityV2TargetRatioCheck = await redeploy('LiquityV2TargetRatioCheck', addrs[network].REGISTRY_ADDR, false, isFork);
-    const liquityV2QuotePriceTrigger = await redeploy('LiquityV2QuotePriceTrigger', addrs[network].REGISTRY_ADDR, false, isFork);
-    const sendTokensAndUnwrap = await redeploy('SendTokensAndUnwrap', addrs[network].REGISTRY_ADDR, false, isFork);
+    const liquityV2RatioTrigger = await redeploy('LiquityV2RatioTrigger', addrs[network].REGISTRY_ADDR, isFork);
+    const liquityV2RatioCheck = await redeploy('LiquityV2RatioCheck', addrs[network].REGISTRY_ADDR, isFork);
+    const closePriceTrigger = await redeploy('ClosePriceTrigger', addrs[network].REGISTRY_ADDR, isFork);
+    const liquityV2TargetRatioCheck = await redeploy('LiquityV2TargetRatioCheck', addrs[network].REGISTRY_ADDR, isFork);
+    const liquityV2QuotePriceTrigger = await redeploy('LiquityV2QuotePriceTrigger', addrs[network].REGISTRY_ADDR, isFork);
+    const sendTokensAndUnwrap = await redeploy('SendTokensAndUnwrap', addrs[network].REGISTRY_ADDR, isFork);
     console.log(`LiquityV2RatioTrigger: ${liquityV2RatioTrigger.address}`);
     console.log(`LiquityV2RatioCheck: ${liquityV2RatioCheck.address}`);
     console.log(`ClosePriceTrigger: ${closePriceTrigger.address}`);

--- a/scripts/deploy-llamalend.js
+++ b/scripts/deploy-llamalend.js
@@ -15,18 +15,18 @@ async function main() {
     const senderAcc = (await hre.ethers.getSigners())[0];
     await topUp(senderAcc.address);
     await topUp(getOwnerAddr());
-    await redeploy('LlamaLendCreate', addrs[network].REGISTRY_ADDR, true, true);
-    await redeploy('LlamaLendSupply', addrs[network].REGISTRY_ADDR, true, true);
-    await redeploy('LlamaLendBorrow', addrs[network].REGISTRY_ADDR, true, true);
-    await redeploy('LlamaLendSelfLiquidate', addrs[network].REGISTRY_ADDR, true, true);
-    await redeploy('LlamaLendPayback', addrs[network].REGISTRY_ADDR, true, true);
-    await redeploy('LlamaLendWithdraw', addrs[network].REGISTRY_ADDR, true, true);
-    await redeploy('LlamaLendGetDebt', addrs[network].REGISTRY_ADDR, true, true);
-    await redeploy('LlamaLendBoost', addrs[network].REGISTRY_ADDR, true, true);
-    await redeploy('LlamaLendRepay', addrs[network].REGISTRY_ADDR, true, true);
-    await redeploy('LlamaLendLevCreate', addrs[network].REGISTRY_ADDR, true, true);
-    await redeploy('LlamaLendSelfLiquidateWithColl', addrs[network].REGISTRY_ADDR, true, true);
-    await redeploy('LlamaLendSwapper', addrs[network].REGISTRY_ADDR, true, true);
+    await redeploy('LlamaLendCreate', addrs[network].REGISTRY_ADDR, true);
+    await redeploy('LlamaLendSupply', addrs[network].REGISTRY_ADDR, true);
+    await redeploy('LlamaLendBorrow', addrs[network].REGISTRY_ADDR, true);
+    await redeploy('LlamaLendSelfLiquidate', addrs[network].REGISTRY_ADDR, true);
+    await redeploy('LlamaLendPayback', addrs[network].REGISTRY_ADDR, true);
+    await redeploy('LlamaLendWithdraw', addrs[network].REGISTRY_ADDR, true);
+    await redeploy('LlamaLendGetDebt', addrs[network].REGISTRY_ADDR, true);
+    await redeploy('LlamaLendBoost', addrs[network].REGISTRY_ADDR, true);
+    await redeploy('LlamaLendRepay', addrs[network].REGISTRY_ADDR, true);
+    await redeploy('LlamaLendLevCreate', addrs[network].REGISTRY_ADDR, true);
+    await redeploy('LlamaLendSelfLiquidateWithColl', addrs[network].REGISTRY_ADDR, true);
+    await redeploy('LlamaLendSwapper', addrs[network].REGISTRY_ADDR, true);
 }
 
 start(main);

--- a/scripts/deploy-lsv-and-staking.js
+++ b/scripts/deploy-lsv-and-staking.js
@@ -11,12 +11,12 @@ async function main() {
     await topUp(senderAcc.address);
     await topUp(getOwnerAddr());
 
-    const lsvSell = await redeploy('LSVSell', addrs[network].REGISTRY_ADDR, false, true);
-    const etherFiStake = await redeploy('EtherFiStake', addrs[network].REGISTRY_ADDR, false, true);
-    const etherFiWrap = await redeploy('EtherFiWrap', addrs[network].REGISTRY_ADDR, false, true);
-    const etherFiUnwrap = await redeploy('EtherFiUnwrap', addrs[network].REGISTRY_ADDR, false, true);
-    const renzoStake = await redeploy('RenzoStake', addrs[network].REGISTRY_ADDR, false, true);
-    const lsvView = await redeploy('LSVView', addrs[network].REGISTRY_ADDR, false, true);
+    const lsvSell = await redeploy('LSVSell', addrs[network].REGISTRY_ADDR, true);
+    const etherFiStake = await redeploy('EtherFiStake', addrs[network].REGISTRY_ADDR, true);
+    const etherFiWrap = await redeploy('EtherFiWrap', addrs[network].REGISTRY_ADDR, true);
+    const etherFiUnwrap = await redeploy('EtherFiUnwrap', addrs[network].REGISTRY_ADDR, true);
+    const renzoStake = await redeploy('RenzoStake', addrs[network].REGISTRY_ADDR, true);
+    const lsvView = await redeploy('LSVView', addrs[network].REGISTRY_ADDR, true);
     console.log(`LSVSell: ${lsvSell.address}`);
     console.log(`EtherFiStake: ${etherFiStake.address}`);
     console.log(`EtherFiWrap: ${etherFiWrap.address}`);

--- a/scripts/deploy-lsv.js
+++ b/scripts/deploy-lsv.js
@@ -16,8 +16,8 @@ async function main() {
     // STEP 1 : npx hardhat compile
 
     // STEP 2 : Deploy LSVProxyRegistry & LSVProfitTracker (node scripts/deploy-lsv --network fork)
-    const proxyRegistry = await redeploy('LSVProxyRegistry', addrs[network].REGISTRY_ADDR, true, true);
-    const profitTracker = await redeploy('LSVProfitTracker', addrs[network].REGISTRY_ADDR, true, true);
+    const proxyRegistry = await redeploy('LSVProxyRegistry', addrs[network].REGISTRY_ADDR, true);
+    const profitTracker = await redeploy('LSVProfitTracker', addrs[network].REGISTRY_ADDR, true);
 
     console.log('LSVProxyRegistry deployed to:', proxyRegistry.address);
     console.log('LSVProfitTracker deployed to:', profitTracker.address);
@@ -30,14 +30,14 @@ async function main() {
 
     /*
     // STEP 7 : Deploy all other actions (node scripts/deploy-lsv --network fork)
-    const test1 = await redeploy('LSVSupply', addrs[network].REGISTRY_ADDR, true, true);
-    const test2 = await redeploy('LSVBorrow', addrs[network].REGISTRY_ADDR, true, true);
-    const test3 = await redeploy('LSVPayback', addrs[network].REGISTRY_ADDR, true, true);
-    const test4 = await redeploy('LSVWithdraw', addrs[network].REGISTRY_ADDR, true, true);
-    const test5 = await redeploy('LSVSell', addrs[network].REGISTRY_ADDR, true, true);
-    const test6 = await redeploy('ApproveToken', addrs[network].REGISTRY_ADDR, true, true);
-    const test7 = await redeploy('MorphoAaveV3SetManager', addrs[network].REGISTRY_ADDR, true, true);
-    const test8 = await redeploy('LSVView', addrs[network].REGISTRY_ADDR, true, true);
+    const test1 = await redeploy('LSVSupply', addrs[network].REGISTRY_ADDR, true);
+    const test2 = await redeploy('LSVBorrow', addrs[network].REGISTRY_ADDR, true);
+    const test3 = await redeploy('LSVPayback', addrs[network].REGISTRY_ADDR, true);
+    const test4 = await redeploy('LSVWithdraw', addrs[network].REGISTRY_ADDR, true);
+    const test5 = await redeploy('LSVSell', addrs[network].REGISTRY_ADDR, true);
+    const test6 = await redeploy('ApproveToken', addrs[network].REGISTRY_ADDR, true);
+    const test7 = await redeploy('MorphoAaveV3SetManager', addrs[network].REGISTRY_ADDR, true);
+    const test8 = await redeploy('LSVView', addrs[network].REGISTRY_ADDR, true);
 
     console.log('LSVSupply deployed to:', test1.address);
     console.log('LSVBorrow deployed to:', test2.address);

--- a/scripts/deploy-morpho-boost-on-price.js
+++ b/scripts/deploy-morpho-boost-on-price.js
@@ -66,8 +66,8 @@ async function main() {
         await addBotCaller(bots[i], addrs[network].REGISTRY_ADDR, isFork);
     }
 
-    const morphoBluePriceTrigger = await redeploy('MorphoBluePriceTrigger', addrs[network].REGISTRY_ADDR, false, isFork);
-    const morphoBlueTargetRatioCheck = await redeploy('MorphoBlueTargetRatioCheck', addrs[network].REGISTRY_ADDR, false, isFork);
+    const morphoBluePriceTrigger = await redeploy('MorphoBluePriceTrigger', addrs[network].REGISTRY_ADDR, isFork);
+    const morphoBlueTargetRatioCheck = await redeploy('MorphoBlueTargetRatioCheck', addrs[network].REGISTRY_ADDR, isFork);
     console.log('MorphoBluePriceTrigger:', morphoBluePriceTrigger.address);
     console.log('MorphoBlueTargetRatioCheck:', morphoBlueTargetRatioCheck.address);
 

--- a/scripts/deploy-morpho-reallocation-action.js
+++ b/scripts/deploy-morpho-reallocation-action.js
@@ -18,6 +18,6 @@ async function main() {
     const senderAcc = (await hre.ethers.getSigners())[0];
     await topUp(senderAcc.address);
     await topUp(getOwnerAddr());
-    await redeploy('MorphoBlueReallocateLiquidity', addrs[network].REGISTRY_ADDR, false, true);
+    await redeploy('MorphoBlueReallocateLiquidity', addrs[network].REGISTRY_ADDR, true);
 }
 start(main);

--- a/scripts/deploy-morpho.js
+++ b/scripts/deploy-morpho.js
@@ -24,10 +24,10 @@ async function main() {
     // );
     // console.log(`MorphoMarketStorage: ${morphoMarketStorage.address}`);
 
-    const morphoAaveV3Supply = await redeploy('MorphoAaveV3Supply', addrs[network].REGISTRY_ADDR, true, true);
-    const morphoAaveV3Borrow = await redeploy('MorphoAaveV3Borrow', addrs[network].REGISTRY_ADDR, true, true);
-    const morphoAaveV3Withdraw = await redeploy('MorphoAaveV3Withdraw', addrs[network].REGISTRY_ADDR, true, true);
-    const morphoAaveV3Payback = await redeploy('MorphoAaveV3Payback', addrs[network].REGISTRY_ADDR, true, true);
+    const morphoAaveV3Supply = await redeploy('MorphoAaveV3Supply', addrs[network].REGISTRY_ADDR, true);
+    const morphoAaveV3Borrow = await redeploy('MorphoAaveV3Borrow', addrs[network].REGISTRY_ADDR, true);
+    const morphoAaveV3Withdraw = await redeploy('MorphoAaveV3Withdraw', addrs[network].REGISTRY_ADDR, true);
+    const morphoAaveV3Payback = await redeploy('MorphoAaveV3Payback', addrs[network].REGISTRY_ADDR, true);
 
     console.log(`MorphoAaveV3Supply: ${morphoAaveV3Supply.address}`);
     console.log(`MorphoAaveV3Borrow: ${morphoAaveV3Borrow.address}`);

--- a/scripts/deploy-morphoBlue.js
+++ b/scripts/deploy-morphoBlue.js
@@ -15,7 +15,7 @@ async function main() {
     // replace hardhat_setStorage to hardhat_setStorage accross the repo
     // RUN SCRIPT WITH: node scripts/deploy-morphoBlue --network fork
 
-    // const lsvView = await redeploy('LSVView', addrs.mainnet.REGISTRY_ADDR, true, true);
+    // const lsvView = await redeploy('LSVView', addrs.mainnet.REGISTRY_ADDR, true);
 
     // console.log('LSVView deployed to:', lsvView.address);
     const marketParams = [

--- a/scripts/deploy-new-compV3-automation.js
+++ b/scripts/deploy-new-compV3-automation.js
@@ -23,7 +23,7 @@ async function main() {
     console.log(repayBundleId, boostBundleId, repayBundleEOAId, boostBundleEOAId);
 
     await redeploy(
-        'CompV3SubProxy', addrs[network].REGISTRY_ADDR, true, true, repayBundleId, boostBundleId, repayBundleEOAId, boostBundleEOAId,
+        'CompV3SubProxy', addrs[network].REGISTRY_ADDR, true, repayBundleId, boostBundleId, repayBundleEOAId, boostBundleEOAId,
     );
 
     process.exit(0);

--- a/scripts/deploy-v3.1-fork.js
+++ b/scripts/deploy-v3.1-fork.js
@@ -14,26 +14,26 @@ async function main() {
 
     await topUp(addrs[network].OWNER_ACC);
 
-    await redeploy('CreateSub', addrs[network].REGISTRY_ADDR, true, true);
-    await redeploy('McdRepayComposite', addrs[network].REGISTRY_ADDR, true, true);
-    await redeploy('McdBoostComposite', addrs[network].REGISTRY_ADDR, true, true);
+    await redeploy('CreateSub', addrs[network].REGISTRY_ADDR, true);
+    await redeploy('McdRepayComposite', addrs[network].REGISTRY_ADDR, true);
+    await redeploy('McdBoostComposite', addrs[network].REGISTRY_ADDR, true);
 
 
-    // const recipeExecutor = await redeploy('RecipeExecutor', addrs[network].REGISTRY_ADDR, true, true);
+    // const recipeExecutor = await redeploy('RecipeExecutor', addrs[network].REGISTRY_ADDR, true);
 
-    // const safeModuleAuth = await redeploy('SafeModuleAuth', addrs[network].REGISTRY_ADDR, true, true);
+    // const safeModuleAuth = await redeploy('SafeModuleAuth', addrs[network].REGISTRY_ADDR, true);
 
-    // const flAction = await redeploy('FLAction', addrs[network].REGISTRY_ADDR, true, true);
+    // const flAction = await redeploy('FLAction', addrs[network].REGISTRY_ADDR, true);
 
-    // const dfsSell = await redeploy('DFSSell', addrs[network].REGISTRY_ADDR, true, true);
+    // const dfsSell = await redeploy('DFSSell', addrs[network].REGISTRY_ADDR, true);
 
-    // const uniswapWrapper = await redeploy('UniswapWrapperV3', addrs[network].REGISTRY_ADDR, true, true);
+    // const uniswapWrapper = await redeploy('UniswapWrapperV3', addrs[network].REGISTRY_ADDR, true);
     // await setNewExchangeWrapper('UniswapWrapperV3', uniswapWrapper.address, true);
 
-    // const uniV3WrapperV3 = await redeploy('UniV3WrapperV3', addrs[network].REGISTRY_ADDR, true, true);
+    // const uniV3WrapperV3 = await redeploy('UniV3WrapperV3', addrs[network].REGISTRY_ADDR, true);
     // await setNewExchangeWrapper('UniV3WrapperV3', uniV3WrapperV3.address, true);
 
-    // const curveWrapperV3 = await redeploy('CurveWrapperV3', addrs[network].REGISTRY_ADDR, true, true);
+    // const curveWrapperV3 = await redeploy('CurveWrapperV3', addrs[network].REGISTRY_ADDR, true);
     // await setNewExchangeWrapper('CurveWrapperV3', curveWrapperV3.address, true);
 
     // console.log('CurveWrapperV3 deployed to:', curveWrapperV3.address);

--- a/scripts/deploy-v3.1.js
+++ b/scripts/deploy-v3.1.js
@@ -13,68 +13,68 @@ async function main() {
     await topUp(senderAcc.address);
 
     // core
-    const recipeExecutor = await redeploy('RecipeExecutor', addrs[network].REGISTRY_ADDR, true, true);
-    const safeModuleAuth = await redeploy('SafeModuleAuth', addrs[network].REGISTRY_ADDR, true, true);
-    const strategyExecutor = await redeploy('StrategyExecutor', addrs[network].REGISTRY_ADDR, true, true);
+    const recipeExecutor = await redeploy('RecipeExecutor', addrs[network].REGISTRY_ADDR, true);
+    const safeModuleAuth = await redeploy('SafeModuleAuth', addrs[network].REGISTRY_ADDR, true);
+    const strategyExecutor = await redeploy('StrategyExecutor', addrs[network].REGISTRY_ADDR, true);
 
     // new fl action
-    const flAction = await redeploy('FLAction', addrs[network].REGISTRY_ADDR, true, true);
+    const flAction = await redeploy('FLAction', addrs[network].REGISTRY_ADDR, true);
 
     // actions with sell that had .owner()
-    const dfsSell = await redeploy('DFSSell', addrs[network].REGISTRY_ADDR, true, true);
-    const limitSell = await redeploy('LimitSell', addrs[network].REGISTRY_ADDR, true, true);
-    const lsvSell = await redeploy('LSVSell', addrs[network].REGISTRY_ADDR, true, true);
+    const dfsSell = await redeploy('DFSSell', addrs[network].REGISTRY_ADDR, true);
+    const limitSell = await redeploy('LimitSell', addrs[network].REGISTRY_ADDR, true);
+    const lsvSell = await redeploy('LSVSell', addrs[network].REGISTRY_ADDR, true);
 
     // wrappers
-    const kyberAggregatorWrapper = await redeploy('KyberAggregatorWrapper', addrs[network].REGISTRY_ADDR, true, true);
+    const kyberAggregatorWrapper = await redeploy('KyberAggregatorWrapper', addrs[network].REGISTRY_ADDR, true);
     await setNewExchangeWrapper('KyberAggregatorWrapper', kyberAggregatorWrapper.address, true);
 
-    const oneInchWrapper = await redeploy('OneInchWrapper', addrs[network].REGISTRY_ADDR, true, true);
+    const oneInchWrapper = await redeploy('OneInchWrapper', addrs[network].REGISTRY_ADDR, true);
     await setNewExchangeWrapper('OneInchWrapper', oneInchWrapper.address, true);
 
-    const paraswapWrapper = await redeploy('ParaswapWrapper', addrs[network].REGISTRY_ADDR, true, true);
+    const paraswapWrapper = await redeploy('ParaswapWrapper', addrs[network].REGISTRY_ADDR, true);
     await setNewExchangeWrapper('ParaswapWrapper', paraswapWrapper.address, true);
 
-    const zeroxWrapper = await redeploy('ZeroxWrapper', addrs[network].REGISTRY_ADDR, true, true);
+    const zeroxWrapper = await redeploy('ZeroxWrapper', addrs[network].REGISTRY_ADDR, true);
     await setNewExchangeWrapper('ZeroxWrapper', zeroxWrapper.address, true);
 
-    const curveWrapperV3 = await redeploy('CurveWrapperV3', addrs[network].REGISTRY_ADDR, true, true);
+    const curveWrapperV3 = await redeploy('CurveWrapperV3', addrs[network].REGISTRY_ADDR, true);
     await setNewExchangeWrapper('CurveWrapperV3', curveWrapperV3.address, true);
 
-    const kyberWrapperV3 = await redeploy('KyberWrapperV3', addrs[network].REGISTRY_ADDR, true, true);
+    const kyberWrapperV3 = await redeploy('KyberWrapperV3', addrs[network].REGISTRY_ADDR, true);
     await setNewExchangeWrapper('KyberWrapperV3', kyberWrapperV3.address, true);
 
-    const uniswapWrapper = await redeploy('UniswapWrapperV3', addrs[network].REGISTRY_ADDR, true, true);
+    const uniswapWrapper = await redeploy('UniswapWrapperV3', addrs[network].REGISTRY_ADDR, true);
     await setNewExchangeWrapper('UniswapWrapperV3', uniswapWrapper.address, true);
 
-    const uniV3WrapperV3 = await redeploy('UniV3WrapperV3', addrs[network].REGISTRY_ADDR, true, true);
+    const uniV3WrapperV3 = await redeploy('UniV3WrapperV3', addrs[network].REGISTRY_ADDR, true);
     await setNewExchangeWrapper('UniV3WrapperV3', uniV3WrapperV3.address, true);
 
 
     // sub proxies
-    const subProxy = await redeploy('SubProxy', addrs[network].REGISTRY_ADDR, true, true);
-    const aaveSubProxy = await redeploy('AaveSubProxy', addrs[network].REGISTRY_ADDR, true, true, 22, 23);
-    const aaveV3SubProxy = await redeploy('AaveV3SubProxy', addrs[network].REGISTRY_ADDR, true, true, 8, 9);
-    const compSubProxy = await redeploy('CompSubProxy', addrs[network].REGISTRY_ADDR, true, true, 20, 21);
-    const compV3SubProxy = await redeploy('CompV3SubProxy', addrs[network].REGISTRY_ADDR, true, true, 28, 29, 30, 31);
-    const limitOrderSubProxy = await redeploy('LimitOrderSubProxy', addrs[network].REGISTRY_ADDR, true, true, 51);
-    const liquitySubProxy = await redeploy('LiquitySubProxy', addrs[network].REGISTRY_ADDR, true, true, 16, 17);
-    const cbRebondSubProxy = await redeploy('CBRebondSubProxy', addrs[network].REGISTRY_ADDR, true, true);
-    const mcdSubProxy = await redeploy('McdSubProxy', addrs[network].REGISTRY_ADDR, true, true, 10, 11);
-    const morphoAaveV2SubProxy = await redeploy('MorphoAaveV2SubProxy', addrs[network].REGISTRY_ADDR, true, true, 14, 15);
-    const sparkSubProxy = await redeploy('SparkSubProxy', addrs[network].REGISTRY_ADDR, true, true, 18, 19);
+    const subProxy = await redeploy('SubProxy', addrs[network].REGISTRY_ADDR, true);
+    const aaveSubProxy = await redeploy('AaveSubProxy', addrs[network].REGISTRY_ADDR, true, 22, 23);
+    const aaveV3SubProxy = await redeploy('AaveV3SubProxy', addrs[network].REGISTRY_ADDR, true, 8, 9);
+    const compSubProxy = await redeploy('CompSubProxy', addrs[network].REGISTRY_ADDR, true, 20, 21);
+    const compV3SubProxy = await redeploy('CompV3SubProxy', addrs[network].REGISTRY_ADDR, true, 28, 29, 30, 31);
+    const limitOrderSubProxy = await redeploy('LimitOrderSubProxy', addrs[network].REGISTRY_ADDR, true, 51);
+    const liquitySubProxy = await redeploy('LiquitySubProxy', addrs[network].REGISTRY_ADDR, true, 16, 17);
+    const cbRebondSubProxy = await redeploy('CBRebondSubProxy', addrs[network].REGISTRY_ADDR, true);
+    const mcdSubProxy = await redeploy('McdSubProxy', addrs[network].REGISTRY_ADDR, true, 10, 11);
+    const morphoAaveV2SubProxy = await redeploy('MorphoAaveV2SubProxy', addrs[network].REGISTRY_ADDR, true, 14, 15);
+    const sparkSubProxy = await redeploy('SparkSubProxy', addrs[network].REGISTRY_ADDR, true, 18, 19);
 
     // actions that use &eoa
-    const sendTokenAndUnwrap = await redeploy('SendTokenAndUnwrap', addrs[network].REGISTRY_ADDR, true, true);
-    const sendTokens = await redeploy('SendTokens', addrs[network].REGISTRY_ADDR, true, true);
-    const sendToken = await redeploy('SendToken', addrs[network].REGISTRY_ADDR, true, true);
-    const curveUsdRepay = await redeploy('CurveUsdRepay', addrs[network].REGISTRY_ADDR, true, true);
-    const curveUsdPayback = await redeploy('CurveUsdPayback', addrs[network].REGISTRY_ADDR, true, true);
-    const compoundV3Withdraw = await redeploy('CompV3Withdraw', addrs[network].REGISTRY_ADDR, true, true);
-    const compoundV3Payback = await redeploy('CompV3Payback', addrs[network].REGISTRY_ADDR, true, true);
-    const compoundV3RatioCheck = await redeploy('CompV3RatioCheck', addrs[network].REGISTRY_ADDR, true, true);
-    const compoundV3Borrow = await redeploy('CompV3Borrow', addrs[network].REGISTRY_ADDR, true, true);
-    const compoundV3Supply = await redeploy('CompV3Supply', addrs[network].REGISTRY_ADDR, true, true);
+    const sendTokenAndUnwrap = await redeploy('SendTokenAndUnwrap', addrs[network].REGISTRY_ADDR, true);
+    const sendTokens = await redeploy('SendTokens', addrs[network].REGISTRY_ADDR, true);
+    const sendToken = await redeploy('SendToken', addrs[network].REGISTRY_ADDR, true);
+    const curveUsdRepay = await redeploy('CurveUsdRepay', addrs[network].REGISTRY_ADDR, true);
+    const curveUsdPayback = await redeploy('CurveUsdPayback', addrs[network].REGISTRY_ADDR, true);
+    const compoundV3Withdraw = await redeploy('CompV3Withdraw', addrs[network].REGISTRY_ADDR, true);
+    const compoundV3Payback = await redeploy('CompV3Payback', addrs[network].REGISTRY_ADDR, true);
+    const compoundV3RatioCheck = await redeploy('CompV3RatioCheck', addrs[network].REGISTRY_ADDR, true);
+    const compoundV3Borrow = await redeploy('CompV3Borrow', addrs[network].REGISTRY_ADDR, true);
+    const compoundV3Supply = await redeploy('CompV3Supply', addrs[network].REGISTRY_ADDR, true);
 
     console.log('KyberAggregatorWrapper deployed to:', kyberAggregatorWrapper.address);
     console.log('OneInchWrapper deployed to:', oneInchWrapper.address);

--- a/scripts/hardhat-tasks.js
+++ b/scripts/hardhat-tasks.js
@@ -49,17 +49,3 @@ task('encryptPrivateKey', 'Encrypt private key')
     .setAction(async () => {
         encryptPrivateKey();
     });
-
-task('create-fork', 'Starts a new mainnet fork')
-    .setAction(async () => {
-        const forkId = await createFork();
-
-        console.log(`Fork id: ${forkId}\nRpc url https://rpc.tenderly.co/fork/${forkId}`);
-    });
-
-task('gib-fork-money', 'Gives specified account 100 Eth on fork')
-    .addOptionalPositionalParam('account', 'Account you want to add Eth to')
-    .setAction(async (args) => {
-        await topUp(args.account);
-        console.log(`Acc: ${args.account} credited with 100 Eth`);
-    });

--- a/scripts/utils/fork.js
+++ b/scripts/utils/fork.js
@@ -1,11 +1,13 @@
 /* eslint-disable import/no-extraneous-dependencies */
 
 const axios = require('axios');
+const { randomUUID } = require('crypto');
 
 const chainIds = {
     mainnet: 1,
     optimism: 10,
     arbitrum: 42161,
+    base: 8453,
 };
 
 const createFork = async (network) => {
@@ -14,29 +16,40 @@ const createFork = async (network) => {
             'Content-Type': 'application/json',
             'X-Access-Key': process.env.TENDERLY_ACCESS_KEY,
         };
-
-        let chainId = '1';
-
-        if (network) {
-            chainId = chainIds[network];
-        }
-
-        const body = { network_id: chainId };
-
-        const forkRes = await axios.post('https://api.tenderly.co/api/v1/account/defisaver-v2/project/strategies/fork', body, { headers });
-
-        return forkRes.data.simulation_fork.id;
+        const chainId = network ? chainIds[network] : 1;
+        const body = {
+            slug: randomUUID(),
+            fork_config: {
+                network_id: chainId,
+                block_number: 'latest',
+            },
+            virtual_network_config: {
+                chain_config: {
+                    chain_id: chainId,
+                },
+            },
+            sync_state_config: {
+                enabled: false,
+            },
+            explorer_page_config: {
+                enabled: true,
+                verification_visibility: 'src',
+            },
+        };
+        const forkRes = await axios.post('https://api.tenderly.co/api/v1/account/defisaver-v2/project/strategies/vnets', body, { headers });
+        const rpcUrl = forkRes.data.rpcs.find((e) => e.name === 'Admin RPC').url;
+        return rpcUrl;
     } catch (err) {
         console.log(err);
         return -1;
     }
 };
 
-const topUp = async (account) => {
+const topUp = async (account, network = 'mainnet') => {
     const body = {
         jsonrpc: '2.0',
         method: 'tenderly_setBalance',
-        params: [[account], '0xFFFFFFFFFFFFFFFFFF'], // ~4700 ETH
+        params: [[account], '0x3635C9ADC5DEA00000'], // 1000 ETH
         id: '1234',
     };
 
@@ -45,7 +58,7 @@ const topUp = async (account) => {
     };
 
     try {
-        await axios.post(`https://virtual.mainnet.rpc.tenderly.co/${process.env.FORK_ID}`, body, { headers });
+        await axios.post(`https://virtual.${network}.rpc.tenderly.co/${process.env.FORK_ID}`, body, { headers });
     } catch (error) {
         console.error('Error:', error.response ? error.response.data : error.message);
     }

--- a/scripts/utils/fork.js
+++ b/scripts/utils/fork.js
@@ -33,14 +33,22 @@ const createFork = async (network) => {
 };
 
 const topUp = async (account) => {
-    const headers = {
-        'Content-Type': 'application/json',
-        'X-Access-Key': process.env.TENDERLY_ACCESS_KEY,
+    const body = {
+        jsonrpc: '2.0',
+        method: 'tenderly_setBalance',
+        params: [[account], '0xFFFFFFFFFFFFFFFFFF'], // ~4700 ETH
+        id: '1234',
     };
 
-    const body = { accounts: [account], amount: 1000000 };
+    const headers = {
+        'Content-Type': 'application/json',
+    };
 
-    await axios.post(`https://api.tenderly.co/api/v1/account/defisaver-v2/project/strategies/fork/${process.env.FORK_ID}/balance`, body, { headers });
+    try {
+        await axios.post(`https://virtual.mainnet.rpc.tenderly.co/${process.env.FORK_ID}`, body, { headers });
+    } catch (error) {
+        console.error('Error:', error.response ? error.response.data : error.message);
+    }
 };
 
 module.exports = {

--- a/test-sol/utils/BaseTest.sol
+++ b/test-sol/utils/BaseTest.sol
@@ -62,7 +62,7 @@ contract BaseTest is Config {
 
     function forkTenderly() internal {
         string memory tenderlyForkId = vm.envString("FORK_ID");
-        string memory base = "https://rpc.tenderly.co/fork/";
+        string memory base = "https://virtual.mainnet.rpc.tenderly.co/";
         string memory forkUrl = string(abi.encodePacked(base, tenderlyForkId));
         uint256 tenderlyFork = vm.createFork(forkUrl);
         vm.selectFork(tenderlyFork);

--- a/test/actions.js
+++ b/test/actions.js
@@ -58,12 +58,6 @@ const executeAction = async (actionName, functionData, proxy, regAddr = addrs[ne
         return receipt;
     } catch (error) {
         console.log(error);
-        /*
-        const blockNum = await hre.ethers.provider.getBlockNumber();
-        const block = await hre.ethers.provider.getBlockWithTransactions(blockNum);
-        const txHash = block.transactions[0].hash;
-        await execShellCommand(`tenderly export ${txHash}`);
-        */
         throw error;
     }
 };

--- a/test/eulerV2/recipe/boost.js
+++ b/test/eulerV2/recipe/boost.js
@@ -35,8 +35,8 @@ const eulerV2BoostTest = async (testPairs) => {
                 await topUp(getOwnerAddr());
             }
             proxy = await getProxy(senderAcc.address, hre.config.isWalletSafe);
-            await redeploy('EulerV2Supply', REGISTRY_ADDR, false, isFork);
-            await redeploy('EulerV2Borrow', REGISTRY_ADDR, false, isFork);
+            await redeploy('EulerV2Supply', REGISTRY_ADDR, isFork);
+            await redeploy('EulerV2Borrow', REGISTRY_ADDR, isFork);
         });
         beforeEach(async () => {
             snapshot = await takeSnapshot();

--- a/test/eulerV2/recipe/create.js
+++ b/test/eulerV2/recipe/create.js
@@ -33,8 +33,8 @@ const eulerV2CreateTest = async (testPair) => {
                 await topUp(getOwnerAddr());
             }
             proxy = await getProxy(senderAcc.address, hre.config.isWalletSafe);
-            await redeploy('EulerV2Supply', REGISTRY_ADDR, false, isFork);
-            await redeploy('EulerV2Borrow', REGISTRY_ADDR, false, isFork);
+            await redeploy('EulerV2Supply', REGISTRY_ADDR, isFork);
+            await redeploy('EulerV2Borrow', REGISTRY_ADDR, isFork);
         });
         beforeEach(async () => {
             snapshot = await takeSnapshot();

--- a/test/eulerV2/recipe/repay.js
+++ b/test/eulerV2/recipe/repay.js
@@ -35,10 +35,10 @@ const eulerV2RepayTest = async (testPairs) => {
                 await topUp(getOwnerAddr());
             }
             proxy = await getProxy(senderAcc.address, hre.config.isWalletSafe);
-            await redeploy('EulerV2Supply', REGISTRY_ADDR, false, isFork);
-            await redeploy('EulerV2Borrow', REGISTRY_ADDR, false, isFork);
-            await redeploy('EulerV2Withdraw', REGISTRY_ADDR, false, isFork);
-            await redeploy('EulerV2Payback', REGISTRY_ADDR, false, isFork);
+            await redeploy('EulerV2Supply', REGISTRY_ADDR, isFork);
+            await redeploy('EulerV2Borrow', REGISTRY_ADDR, isFork);
+            await redeploy('EulerV2Withdraw', REGISTRY_ADDR, isFork);
+            await redeploy('EulerV2Payback', REGISTRY_ADDR, isFork);
         });
         beforeEach(async () => {
             snapshot = await takeSnapshot();

--- a/test/eulerV2/view.js
+++ b/test/eulerV2/view.js
@@ -25,7 +25,7 @@ const eulerV2ViewTest = async () => {
                 await topUp(getOwnerAddr());
                 viewContract = await hre.ethers.getContractAt('EulerV2View', '0x561013c605A17f5dC5b738C8a3fF9c5F33DbC3d8');
             } else {
-                viewContract = await redeploy('EulerV2View', addrs[network].REGISTRY_ADDR, false, isFork);
+                viewContract = await redeploy('EulerV2View', addrs[network].REGISTRY_ADDR, isFork);
             }
         });
         beforeEach(async () => {

--- a/test/fluid/view.js
+++ b/test/fluid/view.js
@@ -31,7 +31,7 @@ const fluidViewTest = async () => {
         let viewContract;
 
         before(async () => {
-            viewContract = await redeploy('FluidView', addrs[network].REGISTRY_ADDR, false, false);
+            viewContract = await redeploy('FluidView', addrs[network].REGISTRY_ADDR, false);
         });
         it('... should call getUserPositions', async () => {
             const userPositions = await viewContract.getUserPositions(TEST_DATA[network].BORROW_USER);

--- a/test/insta/insta-dsa-aaveV3-migration.js
+++ b/test/insta/insta-dsa-aaveV3-migration.js
@@ -115,11 +115,11 @@ describe('DSA-AaveV3-Import', function () {
         dsaProxy = await hre.ethers.getContractAt('IInstaAccountV2', dsaAddress);
         dsaProxy = dsaProxy.connect(userAcc);
 
-        aaveV3View = await getContractFromRegistry('AaveV3View', addrs[network].REGISTRY_ADDR, false, isFork);
-        const flContract = await getContractFromRegistry('FLAction', addrs[network].REGISTRY_ADDR, false, isFork);
+        aaveV3View = await getContractFromRegistry('AaveV3View', addrs[network].REGISTRY_ADDR, isFork);
+        const flContract = await getContractFromRegistry('FLAction', addrs[network].REGISTRY_ADDR, isFork);
         flAddress = flContract.address;
 
-        await redeploy('InstPullTokens', addrs[network].REGISTRY_ADDR, false, isFork);
+        await redeploy('InstPullTokens', addrs[network].REGISTRY_ADDR, isFork);
         wallet = await getProxy(userAddress, hre.config.isWalletSafe);
         wallet = wallet.connect(userAcc);
 

--- a/test/insta/insta-dsa-spark-migration.js
+++ b/test/insta/insta-dsa-spark-migration.js
@@ -114,11 +114,11 @@ describe('DSA-Spark-Import', function () {
         dsaProxy = await hre.ethers.getContractAt('IInstaAccountV2', dsaAddress);
         dsaProxy = dsaProxy.connect(userAcc);
 
-        sparkView = await getContractFromRegistry('SparkView', addrs[network].REGISTRY_ADDR, false, isFork);
-        const flContract = await getContractFromRegistry('FLAction', addrs[network].REGISTRY_ADDR, false, isFork);
+        sparkView = await getContractFromRegistry('SparkView', addrs[network].REGISTRY_ADDR, isFork);
+        const flContract = await getContractFromRegistry('FLAction', addrs[network].REGISTRY_ADDR, isFork);
         flAddress = flContract.address;
 
-        await redeploy('InstPullTokens', addrs[network].REGISTRY_ADDR, false, isFork);
+        await redeploy('InstPullTokens', addrs[network].REGISTRY_ADDR, isFork);
         wallet = await getProxy(userAddress, hre.config.isWalletSafe);
         wallet = wallet.connect(userAcc);
 

--- a/test/morpho-blue/public-allocator.js
+++ b/test/morpho-blue/public-allocator.js
@@ -214,9 +214,9 @@ const morphoBlueReallocateLiquidityTest = async (isFork) => {
                 await topUp(getOwnerAddr());
             }
             proxy = await getProxy(senderAcc.address, hre.config.isWalletSafe);
-            allocateContract = await redeploy('MorphoBlueReallocateLiquidity', addrs[network].REGISTRY_ADDR, false, isFork);
+            allocateContract = await redeploy('MorphoBlueReallocateLiquidity', addrs[network].REGISTRY_ADDR, isFork);
             console.log('Deployed MorphoBlueReallocateLiquidity to address:', allocateContract.address);
-            view = await redeploy('MorphoBlueView', addrs[network].REGISTRY_ADDR, false, isFork);
+            view = await redeploy('MorphoBlueView', addrs[network].REGISTRY_ADDR, isFork);
         });
         beforeEach(async () => { snapshotId = await takeSnapshot(); });
         afterEach(async () => { await revertToSnapshot(snapshotId); });

--- a/test/strategies/aave/aave-tests.js
+++ b/test/strategies/aave/aave-tests.js
@@ -61,7 +61,7 @@ const createBundleAndStrategy = async (proxy) => {
         proxy,
         [boostId1, boostId2],
     );
-    await redeploy('AaveSubProxy', REGISTRY_ADDR, false, false, repayBundleId, boostBundleId);
+    await redeploy('AaveSubProxy', REGISTRY_ADDR, false, repayBundleId, boostBundleId);
     return { repayBundleId, boostBundleId };
 };
 

--- a/test/strategies/aaveV3/aaveV3-open-order.js
+++ b/test/strategies/aaveV3/aaveV3-open-order.js
@@ -106,7 +106,7 @@ const aaveV3OpenOrderStrategyTest = async (isFork, useDeployedStrategies) => {
                 strategyExecutor = await hre.ethers.getContractAt('StrategyExecutorL2', addrs[getNetwork()].STRATEGY_EXECUTOR_ADDR);
             }
             strategyExecutor = strategyExecutor.connect(botAcc);
-            flAction = await getContractFromRegistry('FLAction', REGISTRY_ADDR, false, isFork);
+            flAction = await getContractFromRegistry('FLAction', REGISTRY_ADDR, isFork);
         };
 
         const deployStrategies = async () => {

--- a/test/strategies/aaveV3/aaveV3-tests.js
+++ b/test/strategies/aaveV3/aaveV3-tests.js
@@ -80,7 +80,6 @@ const {
 } = require('../../actions');
 
 const { RATIO_STATE_OVER } = require('../../triggers');
-const { execShellCommand } = require('../../../scripts/hardhat-tasks-functions');
 
 const deployBundles = async (proxy) => {
     await openStrategyAndBundleStorage();
@@ -529,10 +528,6 @@ const aaveV3BoostStrategyTest = async (numTestPairs) => {
                     );
                 } catch (error) {
                     console.log(error);
-                    const blockNum = await hre.ethers.provider.getBlockNumber();
-                    const block = await hre.ethers.provider.getBlockWithTransactions(blockNum);
-                    const txHash = block.transactions[0].hash;
-                    await execShellCommand(`tenderly export ${txHash}`);
                     throw error;
                 }
 

--- a/test/strategies/aaveV3/deploy-open-order.js
+++ b/test/strategies/aaveV3/deploy-open-order.js
@@ -196,7 +196,7 @@ describe('Deploy open order strategies on fork', function () {
                 await topUp(botAccounts[i]);
             }
         }
-        await redeploy('AaveV3OpenRatioCheck', REGISTRY_ADDR, false, isFork);
+        await redeploy('AaveV3OpenRatioCheck', REGISTRY_ADDR, isFork);
         for (let i = 0; i < botAccounts.length; i++) {
             await addBotCaller(botAccounts[i], REGISTRY_ADDR, isFork);
         }
@@ -238,7 +238,7 @@ describe('Deploy open order strategies on fork', function () {
         console.log('\n');
         console.log('#######################################################################');
 
-        // const aaveV3View = await getContractFromRegistry('AaveV3View', REGISTRY_ADDR, false, isFork);
+        // const aaveV3View = await getContractFromRegistry('AaveV3View', REGISTRY_ADDR, isFork);
         // const res = await aaveV3View.getSafetyRatio(addrs[network].AAVE_MARKET, proxyAddr);
         // console.log(res);
     });

--- a/test/strategies/compV3/compV3.js
+++ b/test/strategies/compV3/compV3.js
@@ -169,7 +169,7 @@ describe('CompV3 L2 automation tests', function () {
         strategyExecutorL2 = await hre.ethers.getContractAt('StrategyExecutorL2', STRATEGY_EXECUTOR_L2_ADDR);
 
         const { repayBundleId, boostBundleId } = await deployBundles(proxy);
-        await redeploy('CompV3SubProxyL2', addrs[network].REGISTRY_ADDR, false, false, repayBundleId, boostBundleId);
+        await redeploy('CompV3SubProxyL2', addrs[network].REGISTRY_ADDR, false, repayBundleId, boostBundleId);
     });
 
     beforeEach(async () => {

--- a/test/strategies/compound/compound-tests.js
+++ b/test/strategies/compound/compound-tests.js
@@ -60,7 +60,7 @@ const createBundleAndStrategy = async (proxy) => {
         proxy,
         [boostId1, boostId2],
     );
-    await redeploy('CompSubProxy', REGISTRY_ADDR, false, false, repayBundleId, boostBundleId);
+    await redeploy('CompSubProxy', REGISTRY_ADDR, false, repayBundleId, boostBundleId);
     return { repayBundleId, boostBundleId };
 };
 

--- a/test/strategies/fluid/common.js
+++ b/test/strategies/fluid/common.js
@@ -69,19 +69,19 @@ class BaseFluidT1StrategyTest {
             strategyContractName, addrs[network].STRATEGY_EXECUTOR_ADDR,
         );
         this.contracts.strategyExecutor = strategyExecutor.connect(this.botAcc);
-        this.contracts.flAction = await getContractFromRegistry('FLAction', this.registryAddr, false, this.isFork);
-        this.contracts.view = await redeploy('FluidView', this.registryAddr, false, this.isFork);
-        await redeploy('FluidVaultT1Open', this.registryAddr, false, this.isFork);
-        await redeploy('FluidRatioCheck', this.registryAddr, false, this.isFork);
-        await redeploy('FluidVaultT1Borrow', this.registryAddr, false, this.isFork);
-        await redeploy('FluidVaultT1Supply', this.registryAddr, false, this.isFork);
-        await redeploy('FluidRatioTrigger', this.registryAddr, false, this.isFork);
-        await redeploy('FluidVaultT1Adjust', this.registryAddr, false, this.isFork);
-        await redeploy('FluidVaultT1Withdraw', this.registryAddr, false, this.isFork);
-        await redeploy('FluidVaultT1Payback', this.registryAddr, false, this.isFork);
+        this.contracts.flAction = await getContractFromRegistry('FLAction', this.registryAddr, this.isFork);
+        this.contracts.view = await redeploy('FluidView', this.registryAddr, this.isFork);
+        await redeploy('FluidVaultT1Open', this.registryAddr, this.isFork);
+        await redeploy('FluidRatioCheck', this.registryAddr, this.isFork);
+        await redeploy('FluidVaultT1Borrow', this.registryAddr, this.isFork);
+        await redeploy('FluidVaultT1Supply', this.registryAddr, this.isFork);
+        await redeploy('FluidRatioTrigger', this.registryAddr, this.isFork);
+        await redeploy('FluidVaultT1Adjust', this.registryAddr, this.isFork);
+        await redeploy('FluidVaultT1Withdraw', this.registryAddr, this.isFork);
+        await redeploy('FluidVaultT1Payback', this.registryAddr, this.isFork);
         const mockExchangeName = network === 'mainnet' ? 'MockExchangeWrapperUsdFeed' : 'MockExchangeWrapperUsdFeedL2';
         this.contracts.mockWrapper = await redeploy(
-            mockExchangeName, this.registryAddr, false, this.isFork,
+            mockExchangeName, this.registryAddr, this.isFork,
         );
         await setNewExchangeWrapper(this.senderAcc, this.contracts.mockWrapper.address);
     }

--- a/test/strategies/liquityV2/common.js
+++ b/test/strategies/liquityV2/common.js
@@ -58,16 +58,16 @@ class BaseLiquityV2StrategyTest {
     async setUpContracts() {
         const strategyExecutor = await hre.ethers.getContractAt('StrategyExecutor', addrs[getNetwork()].STRATEGY_EXECUTOR_ADDR);
         this.contracts.strategyExecutor = strategyExecutor.connect(this.botAcc);
-        this.contracts.flAction = await getContractFromRegistry('FLAction', this.registryAddr, false, this.isFork);
-        this.contracts.view = await redeploy('LiquityV2View', this.registryAddr, false, this.isFork);
-        await redeploy('LiquityV2Open', this.registryAddr, false, this.isFork);
-        await redeploy('LiquityV2RatioCheck', this.registryAddr, false, this.isFork);
-        await redeploy('LiquityV2Borrow', this.registryAddr, false, this.isFork);
-        await redeploy('LiquityV2Supply', this.registryAddr, false, this.isFork);
-        await redeploy('LiquityV2RatioTrigger', this.registryAddr, false, this.isFork);
-        await redeploy('LiquityV2Adjust', this.registryAddr, false, this.isFork);
-        await redeploy('LiquityV2Withdraw', this.registryAddr, false, this.isFork);
-        await redeploy('LiquityV2Payback', this.registryAddr, false, this.isFork);
+        this.contracts.flAction = await getContractFromRegistry('FLAction', this.registryAddr, this.isFork);
+        this.contracts.view = await redeploy('LiquityV2View', this.registryAddr, this.isFork);
+        await redeploy('LiquityV2Open', this.registryAddr, this.isFork);
+        await redeploy('LiquityV2RatioCheck', this.registryAddr, this.isFork);
+        await redeploy('LiquityV2Borrow', this.registryAddr, this.isFork);
+        await redeploy('LiquityV2Supply', this.registryAddr, this.isFork);
+        await redeploy('LiquityV2RatioTrigger', this.registryAddr, this.isFork);
+        await redeploy('LiquityV2Adjust', this.registryAddr, this.isFork);
+        await redeploy('LiquityV2Withdraw', this.registryAddr, this.isFork);
+        await redeploy('LiquityV2Payback', this.registryAddr, this.isFork);
     }
 
     async addLiquidity() {

--- a/test/strategies/miscellaneous/misc-tests.js
+++ b/test/strategies/miscellaneous/misc-tests.js
@@ -104,7 +104,7 @@ const limitOrderStrategyTest = async () => {
 
             strategyId = await createStrategy(proxy, ...strategyData, false);
 
-            await redeploy('LimitOrderSubProxy', addrs[getNetwork()].REGISTRY_ADDR, false, false, strategyId);
+            await redeploy('LimitOrderSubProxy', addrs[network].REGISTRY_ADDR, false, strategyId);
         });
 
         for (let i = 0; i < tokenPairs.length; i++) {

--- a/test/strategies/morpho-blue/boost-on-price.js
+++ b/test/strategies/morpho-blue/boost-on-price.js
@@ -221,10 +221,10 @@ const morphoBoostOnPriceStrategyTest = async (isFork, eoaBoost) => {
             const strategyContractName = network === 'mainnet' ? 'StrategyExecutor' : 'StrategyExecutorL2';
             strategyExecutor = await hre.ethers.getContractAt(strategyContractName, addrs[getNetwork()].STRATEGY_EXECUTOR_ADDR);
             strategyExecutor = strategyExecutor.connect(botAcc);
-            flAction = await getContractFromRegistry('FLAction', REGISTRY_ADDR, false, isFork);
+            flAction = await getContractFromRegistry('FLAction', REGISTRY_ADDR, isFork);
             view = await hre.ethers.getContractAt('MorphoBlueHelper', addrs[getNetwork()].MORPHO_BLUE_VIEW);
-            await redeploy('MorphoBluePriceTrigger', REGISTRY_ADDR, false, isFork);
-            await redeploy('MorphoBlueTargetRatioCheck', REGISTRY_ADDR, false, isFork);
+            await redeploy('MorphoBluePriceTrigger', REGISTRY_ADDR, isFork);
+            await redeploy('MorphoBlueTargetRatioCheck', REGISTRY_ADDR, isFork);
 
             // deploy bundle
             boostOnPriceBundleId = await deployBoostOnPriceBundle(isFork);

--- a/test/strategies/morpho/morpho-tests.js
+++ b/test/strategies/morpho/morpho-tests.js
@@ -109,7 +109,7 @@ const morphoAaveV2BoostTest = () => describe('Morpho-AaveV2-Boost-Strategy', fun
         const flStrategyId = await createStrategy(undefined, ...flStrategyData, true);
         bundleId = await createBundle(proxy, [strategyId, flStrategyId]);
 
-        await redeploy('MorphoAaveV2SubProxy', undefined, undefined, undefined, '0', bundleId);
+        await redeploy('MorphoAaveV2SubProxy', undefined, undefined, '0', bundleId);
         triggerRatio = 220;
         const minRatio = 100;
         const targetRepay = 200;
@@ -250,7 +250,7 @@ const morphoAaveV2RepayTest = () => describe('Morpho-AaveV2-Repay-Strategy', fun
         const flStrategyId = await createStrategy(undefined, ...flStrategyData, true);
         const bundleId = await createBundle(proxy, [strategyId, flStrategyId]);
 
-        await redeploy('MorphoAaveV2SubProxy', undefined, undefined, undefined, bundleId, '0');
+        await redeploy('MorphoAaveV2SubProxy', undefined, undefined, bundleId, '0');
         triggerRatio = 280;
         const targetRatio = 300;
 

--- a/test/strategies/spark/spark-tests.js
+++ b/test/strategies/spark/spark-tests.js
@@ -67,7 +67,6 @@ const {
 } = require('../../actions');
 
 const { RATIO_STATE_OVER } = require('../../triggers');
-const { execShellCommand } = require('../../../scripts/hardhat-tasks-functions');
 
 const deployBundles = async (proxy, isFork) => {
     await openStrategyAndBundleStorage(isFork);
@@ -534,10 +533,6 @@ const sparkBoostStrategyTest = async (numTestPairs) => {
                     );
                 } catch (error) {
                     console.log(error);
-                    const blockNum = await hre.ethers.provider.getBlockNumber();
-                    const block = await hre.ethers.provider.getBlockWithTransactions(blockNum);
-                    const txHash = block.transactions[0].hash;
-                    await execShellCommand(`tenderly export ${txHash}`);
                     throw error;
                 }
 

--- a/test/strategies/spark/spark-tests.js
+++ b/test/strategies/spark/spark-tests.js
@@ -85,7 +85,7 @@ const deployBundles = async (proxy, isFork) => {
 
     const boostBundleId = await createBundle(proxy, [strategyId11, strategyId22]);
 
-    await getContractFromRegistry('SparkSubProxy', undefined, undefined, isFork, repayBundleId, boostBundleId);
+    await getContractFromRegistry('SparkSubProxy', undefined, isFork, repayBundleId, boostBundleId);
     return { repayBundleId, boostBundleId };
 };
 

--- a/test/tx-saver/deploy.js
+++ b/test/tx-saver/deploy.js
@@ -22,11 +22,11 @@ describe('Deploy tx saver contracts', function () {
     };
 
     const redeployContracts = async (isFork) => {
-        const bothAuthForTxSaver = await redeploy('BotAuthForTxSaver', addrs[network].REGISTRY_ADDR, false, isFork);
-        const recipeExecutor = await redeploy('RecipeExecutor', addrs[network].REGISTRY_ADDR, false, isFork);
-        const dfsSell = await redeploy('DFSSell', addrs[network].REGISTRY_ADDR, false, isFork);
-        const llamaLendSwapper = await redeploy('LlamaLendSwapper', addrs[network].REGISTRY_ADDR, false, isFork);
-        const txSaverExecutor = await redeploy('TxSaverExecutor', addrs[network].REGISTRY_ADDR, false, isFork);
+        const bothAuthForTxSaver = await redeploy('BotAuthForTxSaver', addrs[network].REGISTRY_ADDR, isFork);
+        const recipeExecutor = await redeploy('RecipeExecutor', addrs[network].REGISTRY_ADDR, isFork);
+        const dfsSell = await redeploy('DFSSell', addrs[network].REGISTRY_ADDR, isFork);
+        const llamaLendSwapper = await redeploy('LlamaLendSwapper', addrs[network].REGISTRY_ADDR, isFork);
+        const txSaverExecutor = await redeploy('TxSaverExecutor', addrs[network].REGISTRY_ADDR, isFork);
 
         console.log('Sender:', senderAcc.address);
         console.log('Safe wallet:', safeWallet.address);

--- a/test/tx-saver/mock-backend-server.js
+++ b/test/tx-saver/mock-backend-server.js
@@ -71,7 +71,7 @@ app.post('/tx-saver', async (req, res) => {
     await topUp(getOwnerAddr());
     await addBotCallerForTxSaver(botAcc.address, true);
 
-    const txSaverExecutor = await getContractFromRegistry('TxSaverExecutor', addrs.mainnet.REGISTRY_ADDR, false, true);
+    const txSaverExecutor = await getContractFromRegistry('TxSaverExecutor', addrs.mainnet.REGISTRY_ADDR, true);
     const txSaverExecutorByBot = txSaverExecutor.connect(botAcc);
 
     const txParams = {

--- a/test/tx-saver/tx-saver-test.js
+++ b/test/tx-saver/tx-saver-test.js
@@ -107,12 +107,12 @@ describe('TxSaver tests', function () {
     };
 
     const redeployContracts = async () => {
-        await redeploy('BotAuthForTxSaver', addrs[network].REGISTRY_ADDR, false, isFork);
-        await redeploy('RecipeExecutor', addrs[network].REGISTRY_ADDR, false, isFork);
-        await redeploy('DFSSell', addrs[network].REGISTRY_ADDR, false, isFork);
+        await redeploy('BotAuthForTxSaver', addrs[network].REGISTRY_ADDR, isFork);
+        await redeploy('RecipeExecutor', addrs[network].REGISTRY_ADDR, isFork);
+        await redeploy('DFSSell', addrs[network].REGISTRY_ADDR, isFork);
 
         recipeExecutorAddr = await getAddrFromRegistry('RecipeExecutor', addrs[network].REGISTRY_ADDR);
-        txSaverExecutor = await redeploy('TxSaverExecutor', addrs[network].REGISTRY_ADDR, false, isFork);
+        txSaverExecutor = await redeploy('TxSaverExecutor', addrs[network].REGISTRY_ADDR, isFork);
 
         const tokenPriceHelperFactory = await hre.ethers.getContractFactory(
             chainIds[network] === 1 ? 'TokenPriceHelper' : 'TokenPriceHelperL2',
@@ -123,9 +123,9 @@ describe('TxSaver tests', function () {
 
     const redeployForLlamaLend = async () => {
         // for testing LlamaLendSwapper with TxSaver
-        await redeploy('LlamaLendLevCreate', addrs[network].REGISTRY_ADDR, false, isFork);
-        await redeploy('LlamaLendSwapper', addrs[network].REGISTRY_ADDR, false, isFork);
-        const mockWrapper = await redeploy('MockExchangeWrapper', addrs[network].REGISTRY_ADDR, false, isFork);
+        await redeploy('LlamaLendLevCreate', addrs[network].REGISTRY_ADDR, isFork);
+        await redeploy('LlamaLendSwapper', addrs[network].REGISTRY_ADDR, isFork);
+        const mockWrapper = await redeploy('MockExchangeWrapper', addrs[network].REGISTRY_ADDR, isFork);
         await setNewExchangeWrapper(senderAcc, mockWrapper.address, isFork);
     };
 

--- a/test/utils-liquity.js
+++ b/test/utils-liquity.js
@@ -78,7 +78,7 @@ const getHints = async (
 
     if (hints !== undefined) return hints;
 
-    const liquityView = await getContractFromRegistry('LiquityView', undefined, undefined, isFork);
+    const liquityView = await getContractFromRegistry('LiquityView', undefined, isFork);
 
     const NICR = await liquityView['predictNICRForAdjust(address,uint8,uint8,address,uint256,uint256)'](troveOwner, actionId, actionId2, from, collAmount, LUSDamount);
 

--- a/test/utils-liquityV2.js
+++ b/test/utils-liquityV2.js
@@ -39,7 +39,7 @@ const getLiquityV2Hints = async (market, collIndex, interestRate, isFork = false
     const seed = 42;
 
     const regAddr = addrs[getNetwork()].REGISTRY_ADDR;
-    const viewContract = await getContractFromRegistry('LiquityV2View', regAddr, false, isFork);
+    const viewContract = await getContractFromRegistry('LiquityV2View', regAddr, isFork);
     const { upperHint, lowerHint } = await viewContract.getInsertPosition(
         market,
         collIndex,

--- a/test/utils.js
+++ b/test/utils.js
@@ -683,7 +683,7 @@ const sendEther = async (signer, toAddress, amount) => {
 };
 
 // eslint-disable-next-line max-len
-const redeploy = async (name, regAddr = addrs[getNetwork()].REGISTRY_ADDR, saveOnTenderly = config.saveOnTenderly, isFork = false, ...args) => {
+const redeploy = async (name, regAddr = addrs[getNetwork()].REGISTRY_ADDR, isFork = false, ...args) => {
     if (!isFork) {
         const setBalanceMethod = hre.network.config.isAnvil ? 'anvil_setBalance' : 'hardhat_setBalance';
         console.log(setBalanceMethod);
@@ -761,13 +761,6 @@ const redeploy = async (name, regAddr = addrs[getNetwork()].REGISTRY_ADDR, saveO
         }
     }
 
-    if (saveOnTenderly) {
-        await hre.tenderly.persistArtifacts({
-            name,
-            address: c.address,
-        });
-    }
-
     return c;
 };
 
@@ -796,13 +789,12 @@ const approveContractInRegistry = async (name, regAddr = addrs[getNetwork()].REG
 const getContractFromRegistry = async (
     name,
     regAddr = addrs[getNetwork()].REGISTRY_ADDR,
-    saveOnTenderly = undefined,
     isFork = undefined,
     ...args
 ) => {
     const contractAddr = await getAddrFromRegistry(name, regAddr);
     if (contractAddr !== nullAddress) return hre.ethers.getContractAt(name, contractAddr);
-    return redeploy(name, regAddr, saveOnTenderly, isFork, ...args);
+    return redeploy(name, regAddr, isFork, ...args);
 };
 
 const setCode = async (addr, code) => {

--- a/test/utils.js
+++ b/test/utils.js
@@ -789,7 +789,7 @@ const approveContractInRegistry = async (name, regAddr = addrs[getNetwork()].REG
 const getContractFromRegistry = async (
     name,
     regAddr = addrs[getNetwork()].REGISTRY_ADDR,
-    isFork = undefined,
+    isFork = false,
     ...args
 ) => {
     const contractAddr = await getAddrFromRegistry(name, regAddr);

--- a/test/views/apy-after-values/test-aaveV3-apy.js
+++ b/test/views/apy-after-values/test-aaveV3-apy.js
@@ -41,7 +41,7 @@ const aaveV3ApyAfterValuesTest = async (isFork) => {
                 await topUp(senderAcc.address);
                 await topUp(getOwnerAddr());
             }
-            aaveV3ViewContract = await redeploy('AaveV3View', addrs[getNetwork()].REGISTRY_ADDR, false, isFork);
+            aaveV3ViewContract = await redeploy('AaveV3View', addrs[network].REGISTRY_ADDR, isFork);
         });
         beforeEach(async () => {
             snapshotId = await takeSnapshot();


### PR DESCRIPTION
- change `topUp` & `createFork` endpoints to work with vNets
- deprecate old forks related setup: `tenderly export ` & `persistArtifacts`
- move utils function to `tenderly-cli.js`
- add automatic verification setup with env variable
- remove `saveOnTenderly` flag from all `redeploy()` & `getContractFromRegistry()` calls