### PR TITLE
improvement: recipe executor addresses

### DIFF
--- a/addresses/mainnet.json
+++ b/addresses/mainnet.json
@@ -3696,7 +3696,7 @@
         "path": "contracts/tx-saver/TxSaverExecutor.sol",
         "version": "1.0.1",
         "inRegistry": true,
-        "changeTime": 0,
+        "changeTime": "86400",
         "registryIds": [],
         "history": ["0x475f433407205557E8A7aeE7Be53155EB9681c92"]
     },

--- a/addresses/mainnet.json
+++ b/addresses/mainnet.json
@@ -910,12 +910,11 @@
         "address": "0x2ee96cf53ae5fbd5309284704f978d0ca66cb963",
         "id": "0x4c69ee1e",
         "path": "contracts/core/RecipeExecutor.sol",
-        "version": "1.0.4",
+        "version": "1.0.3",
         "inRegistry": true,
         "changeTime": "604800",
         "registryIds": [],
         "history": [
-            "0x5029336642814bC51a42bA80BF83a6322110035D",
             "0x5029336642814bC51a42bA80BF83a6322110035D",
             "0xe822d76c2632FC52f3eaa686bDA9Cea3212579D8",
             "0x1D6DEdb49AF91A11B5C5F34954FD3E8cC4f03A86"

--- a/contracts/actions/flashloan/helpers/ArbitrumFLAddresses.sol
+++ b/contracts/actions/flashloan/helpers/ArbitrumFLAddresses.sol
@@ -35,7 +35,5 @@ contract ArbitrumFLAddresses {
     address internal constant UNI_V3_FACTORY = 0x1F98431c8aD98523631AE4a59f267346ea31F984;
     address internal constant MORPHO_BLUE_ADDR = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
 
-    address internal constant RECIPE_EXECUTOR_ADDR = 0x4417bffFD5e3131069f62Fac07e40704EE234404;
-
     address internal constant DFS_REGISTRY_ADDR = 0xBF1CaC12DB60819Bfa71A328282ecbc1D40443aA;
 }

--- a/contracts/actions/flashloan/helpers/ArbitrumFLAddresses.sol
+++ b/contracts/actions/flashloan/helpers/ArbitrumFLAddresses.sol
@@ -36,4 +36,6 @@ contract ArbitrumFLAddresses {
     address internal constant MORPHO_BLUE_ADDR = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
 
     address internal constant RECIPE_EXECUTOR_ADDR = 0x4417bffFD5e3131069f62Fac07e40704EE234404;
+
+    address internal constant DFS_REGISTRY_ADDR = 0xBF1CaC12DB60819Bfa71A328282ecbc1D40443aA;
 }

--- a/contracts/actions/flashloan/helpers/BaseFLAddresses.sol
+++ b/contracts/actions/flashloan/helpers/BaseFLAddresses.sol
@@ -19,8 +19,6 @@ contract BaseFLAddresses {
 
     address internal constant MORPHO_BLUE_ADDR = 0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb;
     
-    address internal constant RECIPE_EXECUTOR_ADDR = 0xd0Ae279e330f98C399375f80968C8bf860202766;
-
     ////////// NOT USED
 
     address internal constant SOLO_MARGIN_ADDRESS = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;

--- a/contracts/actions/flashloan/helpers/BaseFLAddresses.sol
+++ b/contracts/actions/flashloan/helpers/BaseFLAddresses.sol
@@ -37,4 +37,6 @@ contract BaseFLAddresses {
 
     address internal constant CURVEUSD_FLASH_ADDR = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
     address internal constant CURVEUSD_ADDR = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
+
+    address internal constant DFS_REGISTRY_ADDR = 0x347FB634271F666353F23A3362f3935D96F97476;
 }

--- a/contracts/actions/flashloan/helpers/MainnetFLAddresses.sol
+++ b/contracts/actions/flashloan/helpers/MainnetFLAddresses.sol
@@ -32,4 +32,5 @@ contract MainnetFLAddresses {
     address internal constant CURVEUSD_ADDR = 0xf939E0A03FB07F59A73314E73794Be0E57ac1b4E;
 
     address internal constant RECIPE_EXECUTOR_ADDR = 0x5029336642814bC51a42bA80BF83a6322110035D;
+    address internal constant DFS_REGISTRY_ADDR = 0x287778F121F134C66212FB16c9b53eC991D32f5b;
 }

--- a/contracts/actions/flashloan/helpers/MainnetFLAddresses.sol
+++ b/contracts/actions/flashloan/helpers/MainnetFLAddresses.sol
@@ -31,6 +31,5 @@ contract MainnetFLAddresses {
     address internal constant CURVEUSD_FLASH_ADDR = 0xA7a4bb50AF91f90b6fEb3388E7f8286aF45b299B;
     address internal constant CURVEUSD_ADDR = 0xf939E0A03FB07F59A73314E73794Be0E57ac1b4E;
 
-    address internal constant RECIPE_EXECUTOR_ADDR = 0x5029336642814bC51a42bA80BF83a6322110035D;
     address internal constant DFS_REGISTRY_ADDR = 0x287778F121F134C66212FB16c9b53eC991D32f5b;
 }

--- a/contracts/actions/flashloan/helpers/OptimismFLAddresses.sol
+++ b/contracts/actions/flashloan/helpers/OptimismFLAddresses.sol
@@ -36,4 +36,5 @@ contract OptimismFLAddresses {
     address internal constant MORPHO_BLUE_ADDR = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
 
     address internal constant RECIPE_EXECUTOR_ADDR = 0xA532771BD90dAf94b456A4acC9E9cbBdF1367572;
+    address internal constant DFS_REGISTRY_ADDR = 0xAf707Ee480204Ed6e2640B53cE86F680D28Afcbd;
 }

--- a/contracts/actions/flashloan/helpers/OptimismFLAddresses.sol
+++ b/contracts/actions/flashloan/helpers/OptimismFLAddresses.sol
@@ -35,6 +35,5 @@ contract OptimismFLAddresses {
 
     address internal constant MORPHO_BLUE_ADDR = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
 
-    address internal constant RECIPE_EXECUTOR_ADDR = 0xA532771BD90dAf94b456A4acC9E9cbBdF1367572;
     address internal constant DFS_REGISTRY_ADDR = 0xAf707Ee480204Ed6e2640B53cE86F680D28Afcbd;
 }

--- a/contracts/core/helpers/ArbitrumCoreAddresses.sol
+++ b/contracts/core/helpers/ArbitrumCoreAddresses.sol
@@ -7,7 +7,6 @@ contract ArbitrumCoreAddresses {
     address internal constant DEFISAVER_LOGGER = 0xE6f9A5C850dbcD12bc64f40d692F537250aDEC38;
     address internal constant MODULE_AUTH_ADDR = 0xb3D6b7F561C1F250bF7f0F00eFD19FAE6cE533dd;
 
-    address internal constant RECIPE_EXECUTOR_ADDR = 0x4417bffFD5e3131069f62Fac07e40704EE234404;
     address internal constant SUB_STORAGE_ADDR = 0x24ab68395660b910BfBF1cc88BaA316BA06354eE;
     address internal constant BUNDLE_STORAGE_ADDR = 0x8332F2a50A9a6C85a476e1ea33031681291cB694;
     address internal constant STRATEGY_STORAGE_ADDR = 0x6aeA695fcd0655650323e9dc5f80Ac0b15A91Da2;

--- a/contracts/core/helpers/BaseCoreAddresses.sol
+++ b/contracts/core/helpers/BaseCoreAddresses.sol
@@ -7,7 +7,6 @@ contract BaseCoreAddresses {
     address internal constant DEFISAVER_LOGGER = 0xc9D6EfA6e08B66a5Cdc516Bcd5807c2fa69E0f2A;
     address internal constant MODULE_AUTH_ADDR = 0xA9BFa0bFCffBb6d375CE61474BF184E879F4D533;
 
-    address internal constant RECIPE_EXECUTOR_ADDR = 0xd0Ae279e330f98C399375f80968C8bf860202766;
     address internal constant SUB_STORAGE_ADDR = 0x44e98bB58d725F2eF93a195F518b335dCB784c78;
     address internal constant BUNDLE_STORAGE_ADDR = 0x6AB90ff536f0E2a880DbCdef1bB665C2acC0eDdC;
     address internal constant STRATEGY_STORAGE_ADDR = 0x3Ca96CebC7779Ee86685c67c999d0f03158Ee9cA;

--- a/contracts/core/helpers/MainnetCoreAddresses.sol
+++ b/contracts/core/helpers/MainnetCoreAddresses.sol
@@ -12,6 +12,5 @@ contract MainnetCoreAddresses {
     address internal constant BUNDLE_STORAGE_ADDR = 0x223c6aDE533851Df03219f6E3D8B763Bd47f84cf;
     address internal constant STRATEGY_STORAGE_ADDR = 0xF52551F95ec4A2B4299DcC42fbbc576718Dbf933;
 
-    address internal constant RECIPE_EXECUTOR_ADDR = 0x5029336642814bC51a42bA80BF83a6322110035D;
     address internal constant BYTES_TRANSIENT_STORAGE = 0xB3FE6f712c8B8c64CD2780ce714A36e7640DDf0f;
 }

--- a/contracts/core/helpers/OptimismCoreAddresses.sol
+++ b/contracts/core/helpers/OptimismCoreAddresses.sol
@@ -7,7 +7,6 @@ contract OptimismCoreAddresses {
     address internal constant DEFISAVER_LOGGER = 0xFc2f1355296ab7dd98a1260E3Ff5E906999d4Acb;
     address internal constant MODULE_AUTH_ADDR = 0x6D6Bc726955d46AC4EBbEe0f2c3Ed01128E261A6;
 
-    address internal constant RECIPE_EXECUTOR_ADDR = 0xA532771BD90dAf94b456A4acC9E9cbBdF1367572;
     address internal constant SUB_STORAGE_ADDR = 0xb944291Ed31886b20030d0d4C47c7838d1d9eb97;
     address internal constant BUNDLE_STORAGE_ADDR = 0xc98C5312829006b2D4bBd47162d49B1aa6C275Ab;
     address internal constant STRATEGY_STORAGE_ADDR = 0xDdDE69c3Fd246D9D62f9712c814b333728f113A4;

--- a/contracts/core/l2/StrategyExecutorL2.sol
+++ b/contracts/core/l2/StrategyExecutorL2.sol
@@ -21,6 +21,8 @@ contract StrategyExecutorL2 is StrategyModel, AdminAuth, CoreHelper, CheckWallet
 
     bytes4 constant BOT_AUTH_ID = bytes4(keccak256("BotAuth"));
 
+    bytes4 constant RECIPE_EXECUTOR_ID = bytes4(keccak256("RecipeExecutor"));
+
     /// Caller must be authorized bot
     error BotNotApproved(address, uint256);
     /// Subscription must be enabled
@@ -80,7 +82,7 @@ contract StrategyExecutorL2 is StrategyModel, AdminAuth, CoreHelper, CheckWallet
 
         IAuth(authAddr).callExecute{value: msg.value}(
             _userWallet,
-            RECIPE_EXECUTOR_ADDR,
+            registry.getAddr(RECIPE_EXECUTOR_ID),
             abi.encodeWithSelector(
                 EXECUTE_RECIPE_FROM_STRATEGY_SELECTOR,
                 _subId,

--- a/contracts/core/strategy/StrategyExecutor.sol
+++ b/contracts/core/strategy/StrategyExecutor.sol
@@ -21,6 +21,8 @@ contract StrategyExecutor is StrategyModel, AdminAuth, CoreHelper, CheckWalletTy
         bytes4(keccak256("executeRecipeFromStrategy(uint256,bytes[],bytes[],uint256,(uint64,bool,bytes[],bytes32[]))")); 
 
     bytes4 constant BOT_AUTH_ID = bytes4(keccak256("BotAuth"));
+    
+    bytes4 constant RECIPE_EXECUTOR_ID = bytes4(keccak256("RecipeExecutor"));
 
     /// Caller must be authorized bot
     error BotNotApproved(address, uint256);
@@ -72,7 +74,6 @@ contract StrategyExecutor is StrategyModel, AdminAuth, CoreHelper, CheckWalletTy
         return BotAuth(registry.getAddr(BOT_AUTH_ID)).isApproved(_subId, msg.sender);
     }
 
-
     /// @notice Calls auth contract which has the auth from the user wallet which will call RecipeExecutor
     /// @param _subId Strategy data we have in storage
     /// @param _actionsCallData All input data needed to execute actions
@@ -92,7 +93,7 @@ contract StrategyExecutor is StrategyModel, AdminAuth, CoreHelper, CheckWalletTy
 
         IAuth(authAddr).callExecute{value: msg.value}(
             _userWallet,
-            RECIPE_EXECUTOR_ADDR,
+            registry.getAddr(RECIPE_EXECUTOR_ID),
             abi.encodeWithSelector(
                 EXECUTE_RECIPE_FROM_STRATEGY_SELECTOR,
                 _subId,

--- a/test-sol/core/ProxyAuth.t.sol
+++ b/test-sol/core/ProxyAuth.t.sol
@@ -14,6 +14,9 @@ import { SmartWallet } from "../utils/SmartWallet.sol";
 import { Addresses } from "../utils/Addresses.sol";
 
 contract TestCore_ProxyAuth is RegistryUtils, ActionsUtils, BaseTest {
+
+    // TODO: placeholder for now. Fix this tests to use the address from registry
+    address RECIPE_EXECUTOR_ADDR = 0x5029336642814bC51a42bA80BF83a6322110035D;
     
     /*//////////////////////////////////////////////////////////////////////////
                                CONTRACT UNDER TEST

--- a/test-sol/core/ProxyAuth.t.sol
+++ b/test-sol/core/ProxyAuth.t.sol
@@ -15,9 +15,6 @@ import { Addresses } from "../utils/Addresses.sol";
 
 contract TestCore_ProxyAuth is RegistryUtils, ActionsUtils, BaseTest {
 
-    // TODO: placeholder for now. Fix this tests to use the address from registry
-    address RECIPE_EXECUTOR_ADDR = 0x5029336642814bC51a42bA80BF83a6322110035D;
-    
     /*//////////////////////////////////////////////////////////////////////////
                                CONTRACT UNDER TEST
     //////////////////////////////////////////////////////////////////////////*/
@@ -31,6 +28,7 @@ contract TestCore_ProxyAuth is RegistryUtils, ActionsUtils, BaseTest {
     
     address strategyExecutorAddr;
     address dsProxyPermissionAddr;
+    address recipeExecutorAddr;
 
     /*//////////////////////////////////////////////////////////////////////////
                                   SETUP FUNCTION
@@ -46,10 +44,12 @@ contract TestCore_ProxyAuth is RegistryUtils, ActionsUtils, BaseTest {
         cut = ProxyAuth(PROXY_AUTH_ADDR);
 
         dsProxyPermissionAddr = address(new DSProxyPermission());
+
         strategyExecutorAddr = address(new StrategyExecutor());
         redeploy("StrategyExecutorID", strategyExecutorAddr);
 
-        vm.etch(RECIPE_EXECUTOR_ADDR, address(new RecipeExecutor()).code);
+        recipeExecutorAddr = address(new RecipeExecutor());
+        redeploy("RecipeExecutor", recipeExecutorAddr);
     }
 
     /*//////////////////////////////////////////////////////////////////////////
@@ -63,13 +63,13 @@ contract TestCore_ProxyAuth is RegistryUtils, ActionsUtils, BaseTest {
                 strategyExecutorAddr
             )
         );
-        cut.callExecute(dsProxyAddr, RECIPE_EXECUTOR_ADDR, bytes("0x"));
+        cut.callExecute(dsProxyAddr, recipeExecutorAddr, bytes("0x"));
     }
 
     function test_should_fail_to_execute_tx_when_no_auth_is_given() public {
         prank(strategyExecutorAddr);
         vm.expectRevert();
-        cut.callExecute(dsProxyAddr, RECIPE_EXECUTOR_ADDR, bytes("0x"));
+        cut.callExecute(dsProxyAddr, recipeExecutorAddr, bytes("0x"));
     }
 
     function test_should_execute_tx() public {
@@ -102,6 +102,6 @@ contract TestCore_ProxyAuth is RegistryUtils, ActionsUtils, BaseTest {
 
         // execute tx from auth contract
         prank(strategyExecutorAddr);
-        cut.callExecute(dsProxyAddr, RECIPE_EXECUTOR_ADDR, recipeExecutorCalldata);
+        cut.callExecute(dsProxyAddr, recipeExecutorAddr, recipeExecutorCalldata);
     }
 }

--- a/test-sol/core/SafeModuleAuth.t.sol
+++ b/test-sol/core/SafeModuleAuth.t.sol
@@ -16,9 +16,6 @@ import { Addresses } from "../utils/Addresses.sol";
 
 contract TestCore_SafeModuleAuth is RegistryUtils, ActionsUtils, BaseTest {
 
-    // TODO: placeholder for now. Fix this tests to use the address from registry
-    address RECIPE_EXECUTOR_ADDR = 0x5029336642814bC51a42bA80BF83a6322110035D;
-    
     /*//////////////////////////////////////////////////////////////////////////
                                CONTRACT UNDER TEST
     //////////////////////////////////////////////////////////////////////////*/
@@ -32,6 +29,7 @@ contract TestCore_SafeModuleAuth is RegistryUtils, ActionsUtils, BaseTest {
     
     address strategyExecutorAddr;
     address safeModulePermissionAddr;
+    address recipeExecutorAddr;
 
     /*//////////////////////////////////////////////////////////////////////////
                                   SETUP FUNCTION
@@ -50,7 +48,8 @@ contract TestCore_SafeModuleAuth is RegistryUtils, ActionsUtils, BaseTest {
         strategyExecutorAddr = address(new StrategyExecutor());
         redeploy("StrategyExecutorID", strategyExecutorAddr);
 
-        vm.etch(RECIPE_EXECUTOR_ADDR, address(new RecipeExecutor()).code);
+        recipeExecutorAddr = address(new RecipeExecutor());
+        redeploy("RecipeExecutor", recipeExecutorAddr);
     }
 
     /*//////////////////////////////////////////////////////////////////////////
@@ -64,7 +63,7 @@ contract TestCore_SafeModuleAuth is RegistryUtils, ActionsUtils, BaseTest {
                 strategyExecutorAddr
             )
         );
-        cut.callExecute(safeWalletAddr, RECIPE_EXECUTOR_ADDR, bytes("0x"));
+        cut.callExecute(safeWalletAddr, recipeExecutorAddr, bytes("0x"));
     }
 
     function test_should_fail_to_call_execute_when_paused() public {
@@ -73,13 +72,13 @@ contract TestCore_SafeModuleAuth is RegistryUtils, ActionsUtils, BaseTest {
 
         prank(strategyExecutorAddr);
         vm.expectRevert(abi.encodeWithSelector(Pausable.ContractPaused.selector));
-        cut.callExecute(safeWalletAddr, RECIPE_EXECUTOR_ADDR, bytes("0x"));
+        cut.callExecute(safeWalletAddr, recipeExecutorAddr, bytes("0x"));
     }
 
     function test_should_fail_to_execute_safe_tx_when_no_auth_is_given() public {
         prank(strategyExecutorAddr);
         vm.expectRevert();
-        cut.callExecute(safeWalletAddr, RECIPE_EXECUTOR_ADDR, bytes("0x"));
+        cut.callExecute(safeWalletAddr, recipeExecutorAddr, bytes("0x"));
     }
 
     function test_should_execute_safe_tx() public {
@@ -110,7 +109,7 @@ contract TestCore_SafeModuleAuth is RegistryUtils, ActionsUtils, BaseTest {
 
         // execute safe tx
         prank(strategyExecutorAddr);
-        cut.callExecute(safeWalletAddr, RECIPE_EXECUTOR_ADDR, recipeExecutorCalldata);
+        cut.callExecute(safeWalletAddr, recipeExecutorAddr, recipeExecutorCalldata);
     }
 
     function test_should_revert_when_safe_tx_execution_fails() public {
@@ -140,6 +139,6 @@ contract TestCore_SafeModuleAuth is RegistryUtils, ActionsUtils, BaseTest {
         /// @dev we expect revert because we are using recipe with flAction without returning funds
         prank(strategyExecutorAddr);
         vm.expectRevert(abi.encodeWithSelector(SafeModuleAuth.SafeExecutionError.selector));
-        cut.callExecute(safeWalletAddr, RECIPE_EXECUTOR_ADDR, recipeExecutorCalldata);
+        cut.callExecute(safeWalletAddr, recipeExecutorAddr, recipeExecutorCalldata);
     }
 }

--- a/test-sol/core/SafeModuleAuth.t.sol
+++ b/test-sol/core/SafeModuleAuth.t.sol
@@ -15,6 +15,9 @@ import { SmartWallet } from "../utils/SmartWallet.sol";
 import { Addresses } from "../utils/Addresses.sol";
 
 contract TestCore_SafeModuleAuth is RegistryUtils, ActionsUtils, BaseTest {
+
+    // TODO: placeholder for now. Fix this tests to use the address from registry
+    address RECIPE_EXECUTOR_ADDR = 0x5029336642814bC51a42bA80BF83a6322110035D;
     
     /*//////////////////////////////////////////////////////////////////////////
                                CONTRACT UNDER TEST

--- a/test-sol/core/StrategyExecutor.t.sol
+++ b/test-sol/core/StrategyExecutor.t.sol
@@ -22,9 +22,6 @@ import {StrategyBuilder} from '../utils/StrategyBuilder.sol';
 
 contract TestCore_StrategyExecutor is RegistryUtils, ActionsUtils, BaseTest {
 
-    // TODO: placeholder for now. Fix this tests to use the address from registry
-    address RECIPE_EXECUTOR_ADDR = 0x5029336642814bC51a42bA80BF83a6322110035D;
-
     /*//////////////////////////////////////////////////////////////////////////
                                CONTRACT UNDER TEST
     //////////////////////////////////////////////////////////////////////////*/
@@ -61,7 +58,6 @@ contract TestCore_StrategyExecutor is RegistryUtils, ActionsUtils, BaseTest {
         cut = new StrategyExecutor();
         subStorage = SubStorage(SUB_STORAGE_ADDR);
 
-        vm.etch(RECIPE_EXECUTOR_ADDR, address(new RecipeExecutor()).code);
         vm.etch(MODULE_AUTH_ADDR, address(new SafeModuleAuth()).code);
         vm.etch(PROXY_AUTH_ADDR, address(new ProxyAuth()).code);
 
@@ -73,6 +69,7 @@ contract TestCore_StrategyExecutor is RegistryUtils, ActionsUtils, BaseTest {
         redeploy('GasPriceTrigger', address(new GasPriceTrigger()));
         redeploy('SubProxy', subProxyAddr);
         redeploy('BotAuth', botAuthAddr);
+        redeploy("RecipeExecutor", address(new RecipeExecutor()));
     }
 
     /*//////////////////////////////////////////////////////////////////////////

--- a/test-sol/core/StrategyExecutor.t.sol
+++ b/test-sol/core/StrategyExecutor.t.sol
@@ -21,6 +21,10 @@ import {Addresses} from '../utils/Addresses.sol';
 import {StrategyBuilder} from '../utils/StrategyBuilder.sol';
 
 contract TestCore_StrategyExecutor is RegistryUtils, ActionsUtils, BaseTest {
+
+    // TODO: placeholder for now. Fix this tests to use the address from registry
+    address RECIPE_EXECUTOR_ADDR = 0x5029336642814bC51a42bA80BF83a6322110035D;
+
     /*//////////////////////////////////////////////////////////////////////////
                                CONTRACT UNDER TEST
     //////////////////////////////////////////////////////////////////////////*/

--- a/test/utils/addressInjector.js
+++ b/test/utils/addressInjector.js
@@ -18,7 +18,6 @@ class CoreAddressesInjector {
             const newContent = this.contentBeforeInjection
                 .replace(/(PROXY_AUTH_ADDR\s*=\s*)0x[a-fA-F0-9]{40}/, `$1${proxyAuthAddr}`)
                 .replace(/(MODULE_AUTH_ADDR\s*=\s*)0x[a-fA-F0-9]{40}/, `$1${safeModuleAuthAddr}`)
-                .replace(/(RECIPE_EXECUTOR_ADDR\s*=\s*)0x[a-fA-F0-9]{40}/, `$1${recipeExecutorAddr}`);
             fs.writeFileSync(this.contractFilePath, newContent);
             await execAsync('npx hardhat compile');
         } catch (err) {


### PR DESCRIPTION
### Summary

Make FL contracts and StrategyExecutor to use RecipeExecutor from registry instead of hardcoding address.

### Type of change
- [ ] Breaking Change - A change that is not backward-compatible.
- [ ] New Feature - A change that adds functionality.
- [X] Tweak - A change that modifies existing features.
- [ ] Bugfix - A change that resolves an issue.

### Checks
  #### For Modifications to Existing Contracts
  - [x] If there were existing tests for the contract, are they adapted for the change and executed?
  - [ ] Is the contract redeployed and added to the JSON file?
  - [ ] Is the contract verified and added to the Tenderly dashboard?
  - [ ] If some parameters were changed and a breaking change was introduced, is the documentation updated on GitBook?

### References
_Link any existing PRs, such as SDK PRs related to this PR, or any additional references._
