### PR TITLE
feat: skip RATIO_OFFSET check when targetRatio is over or equal to 999%

### DIFF
--- a/addresses/arbitrum.json
+++ b/addresses/arbitrum.json
@@ -1359,14 +1359,16 @@
     },
     {
         "name": "AaveV3OpenRatioCheck",
-        "address": "0x770e015485d4720398B08Ff226DB4ef29896b5B8",
+        "address": "0x99A36d26A2e1E6776057835C7B5E72A20c8cF5cb",
         "id": "0x72b17abf",
         "path": "contracts/actions/checkers/AaveV3OpenRatioCheck.sol",
-        "version": "1.0.0",
+        "version": "1.0.1",
         "inRegistry": true,
         "changeTime": "86400",
         "registryIds": [],
-        "history": []
+        "history": [
+            "0x770e015485d4720398B08Ff226DB4ef29896b5B8"
+        ]
     },
     {
         "name": "FluidVaultT1Open",

--- a/addresses/base.json
+++ b/addresses/base.json
@@ -1277,14 +1277,16 @@
     },
     {
         "name": "AaveV3OpenRatioCheck",
-        "address": "0xFaC6148cf103BcAf3E90f6EB52373a231861Df18",
+        "address": "0x9da74c3C4e2d79e04cfaD434fB679a97613fae7E",
         "id": "0x72b17abf",
         "path": "contracts/actions/checkers/AaveV3OpenRatioCheck.sol",
-        "version": "1.0.0",
+        "version": "1.0.1",
         "inRegistry": true,
         "changeTime": "86400",
         "registryIds": [],
-        "history": []
+        "history": [
+            "0xFaC6148cf103BcAf3E90f6EB52373a231861Df18"
+        ]
     },
     {
         "name": "CreateSub",

--- a/addresses/mainnet.json
+++ b/addresses/mainnet.json
@@ -3742,14 +3742,16 @@
     },
     {
         "name": "AaveV3OpenRatioCheck",
-        "address": "0xaFD184d6E048c3C8D18356ef4E9adA024E6fb31c",
+        "address": "0x7449c0830B10cbd1BaD1Aa4427Ccb41Fd5C75be5",
         "id": "0x72b17abf",
         "path": "contracts/actions/checkers/AaveV3OpenRatioCheck.sol",
-        "version": "1.0.0",
+        "version": "1.0.1",
         "inRegistry": true,
         "changeTime": "86400",
         "registryIds": [],
-        "history": []
+        "history": [
+            "0xaFD184d6E048c3C8D18356ef4E9adA024E6fb31c"
+        ]
     },
     {
         "name": "BotAuthForTxSaver",

--- a/addresses/optimism.json
+++ b/addresses/optimism.json
@@ -1183,14 +1183,16 @@
     },
     {
         "name": "AaveV3OpenRatioCheck",
-        "address": "0xA41baFAE6832D6D059eEcac0eBB46c4D8c16c248",
+        "address": "0xAF5D3604B1bE08fadD239b2A7353F01786cE4b0e",
         "id": "0x72b17abf",
         "path": "contracts/actions/checkers/AaveV3OpenRatioCheck.sol",
-        "version": "1.0.0",
+        "version": "1.0.1",
         "inRegistry": true,
         "changeTime": "86400",
         "registryIds": [],
-        "history": []
+        "history": [
+            "0xA41baFAE6832D6D059eEcac0eBB46c4D8c16c248"
+        ]
     },
     {
         "name": "CompV3RatioTrigger",

--- a/contracts/actions/checkers/AaveV3OpenRatioCheck.sol
+++ b/contracts/actions/checkers/AaveV3OpenRatioCheck.sol
@@ -2,16 +2,15 @@
 
 pragma solidity =0.8.24;
 
-import { ActionBase } from "../ActionBase.sol";
-import { AaveV3RatioHelper } from "../aaveV3/helpers/AaveV3RatioHelper.sol";
+import {ActionBase} from "../ActionBase.sol";
+import {AaveV3RatioHelper} from "../aaveV3/helpers/AaveV3RatioHelper.sol";
 
 /// @title Action to check the ratio of the Aave V3 position after strategy execution.
 /// @notice This action only checks for current ratio, without comparing it to the start ratio.
 contract AaveV3OpenRatioCheck is ActionBase, AaveV3RatioHelper {
-
     /// @notice 5% offset acceptable
     uint256 internal constant RATIO_OFFSET = 50000000000000000;
-    /// @notice 999% is highest ratio that we will check the 5% offset for
+    /// @notice We are checking for 5% RATIO_OFFSET only when the target ratio is < 999%
     uint256 internal constant RATIO_LIMIT = 9990000000000000000;
 
     error BadAfterRatio(uint256 currentRatio, uint256 targetRatio);

--- a/contracts/actions/checkers/AaveV3OpenRatioCheck.sol
+++ b/contracts/actions/checkers/AaveV3OpenRatioCheck.sol
@@ -11,6 +11,8 @@ contract AaveV3OpenRatioCheck is ActionBase, AaveV3RatioHelper {
 
     /// @notice 5% offset acceptable
     uint256 internal constant RATIO_OFFSET = 50000000000000000;
+    /// @notice 999% is highest ratio that we will check the 5% offset for
+    uint256 internal constant RATIO_LIMIT = 9990000000000000000;
 
     error BadAfterRatio(uint256 currentRatio, uint256 targetRatio);
 
@@ -35,8 +37,11 @@ contract AaveV3OpenRatioCheck is ActionBase, AaveV3RatioHelper {
 
         uint256 currRatio = getRatio(market, address(this));
 
-        if (currRatio > (targetRatio + RATIO_OFFSET) || currRatio < (targetRatio - RATIO_OFFSET)) {
-            revert BadAfterRatio(currRatio, targetRatio);
+        /// @notice If `targetRatio` is 999% or more then skip `RATIO_OFFSET` check because it is very hard to be precise under 5%.
+        if (targetRatio < RATIO_LIMIT) {
+            if (currRatio > (targetRatio + RATIO_OFFSET) || currRatio < (targetRatio - RATIO_OFFSET)) {
+                revert BadAfterRatio(currRatio, targetRatio);
+            }
         }
 
         emit ActionEvent("AaveV3OpenRatioCheck", abi.encode(currRatio));


### PR DESCRIPTION
### Summary

Skip the RATIO_OFFSET (5%) check when targetRatio is over or equal to 999%. Only applies to AaveV3 Boost on price and Repay on price strategies.

### Type of change
- [x] Breaking Change - A change that is not backward-compatible.
- [ ] New Feature - A change that adds functionality.
- [ ] Tweak - A change that modifies existing features.
- [ ] Bugfix - A change that resolves an issue.

### Details

_Provide any additional details if needed._

### Checks
  #### For New Contracts
  - [ ] Does the new contract have tests?
  - [ ] Does the contract contain all the NatSpec needed (`@title`, `@notice`, `@param`, etc.)?
  - [ ] Is the contract deployed and the address added to the JSON file?
  - [ ] If the contract is registered, is the waitPeriod set correctly?
  - [ ] Is the contract verified and added to the Tenderly dashboard?
  - [ ] Is documentation written for the corresponding DFS action and added to GitBook?
  
  #### For Modifications to Existing Contracts
  - [ ] If there were existing tests for the contract, are they adapted for the change and executed?
  - [ ] Is the contract redeployed and added to the JSON file?
  - [ ] If the contract is registered, is the waitPeriod set correctly?
  - [ ] Is the contract verified and added to the Tenderly dashboard?
  - [ ] If some parameters were changed and a breaking change was introduced, is the documentation updated on GitBook?
  
  #### For Strategies
  - [ ] Are new tests added for the strategy?
  - [ ] Is the strategy deployed and added to the JSON file?

### References
_Link any existing PRs, such as SDK PRs related to this PR, or any additional references._
