### PR TITLE
feat: add ratio check for aaveV3 repay on price strategy

### DIFF
--- a/contracts/views/strategy/StrategyTriggerViewNoRevert.sol
+++ b/contracts/views/strategy/StrategyTriggerViewNoRevert.sol
@@ -150,7 +150,7 @@ contract StrategyTriggerViewNoRevert is
 
         // check for minDebt but also check if targetRatio is over startRatio
         if (strategyId.isAaveV3RepayOnPriceStrategy()) {
-            return _verifyAaveV3RepayOnPrice(_sub, smartWallet);
+            return _tryToVerifyAaveRepayOnPriceStrategy(_sub, smartWallet);
         }
 
         // check Spark leverage management for only mainnet deployment
@@ -253,6 +253,18 @@ contract StrategyTriggerViewNoRevert is
         IPoolV3 lendingPool = IPoolV3(IPoolAddressesProvider(DEFAULT_AAVE_MARKET).getPool());
         (, uint256 totalDebtUSD,,,,) = lendingPool.getUserAccountData(_smartWallet);
         return _hasEnoughMinDebtInUSD(totalDebtUSD) ? TriggerStatus.TRUE : TriggerStatus.FALSE;
+    }
+
+    function _tryToVerifyAaveRepayOnPriceStrategy(StrategySub memory _sub, address _smartWallet)
+        public
+        view
+        returns (TriggerStatus)
+    {
+        try this._verifyAaveV3RepayOnPrice(_sub, _smartWallet) returns (TriggerStatus status) {
+            return status;
+        } catch {
+            return TriggerStatus.REVERT;
+        }
     }
 
     function _verifyAaveV3RepayOnPrice(StrategySub memory _sub, address _smartWallet)

--- a/contracts/views/strategy/StrategyTriggerViewNoRevert.sol
+++ b/contracts/views/strategy/StrategyTriggerViewNoRevert.sol
@@ -18,13 +18,21 @@ import {StrategyStorage} from "../../core/strategy/StrategyStorage.sol";
 import {TokenUtils} from "../../utils/TokenUtils.sol";
 import {StrategyIDs} from "./StrategyIDs.sol";
 import {AaveV3Helper} from "../../actions/aaveV3/helpers/AaveV3Helper.sol";
+import {AaveV3RatioHelper} from "../../actions/aaveV3/helpers/AaveV3RatioHelper.sol";
 import {UtilHelper} from "../../utils/helpers/UtilHelper.sol";
 import {Denominations} from "../../utils/Denominations.sol";
 import {StableCoinUtils} from "./StableCoinUtils.sol";
 
 /// @title StrategyTriggerViewNoRevert - Helper contract to check whether a trigger is triggered or not for a given sub.
 /// @dev This contract is designed to avoid reverts from checking triggers.
-contract StrategyTriggerViewNoRevert is StrategyModel, CoreHelper, CheckWalletType, AaveV3Helper, UtilHelper {
+contract StrategyTriggerViewNoRevert is
+    StrategyModel,
+    CoreHelper,
+    CheckWalletType,
+    AaveV3Helper,
+    AaveV3RatioHelper,
+    UtilHelper
+{
     DFSRegistry public constant registry = DFSRegistry(REGISTRY_ADDR);
     IFeedRegistry public constant feedRegistry = IFeedRegistry(CHAINLINK_FEED_REGISTRY);
 
@@ -135,12 +143,14 @@ contract StrategyTriggerViewNoRevert is StrategyModel, CoreHelper, CheckWalletTy
             return _tryToVerifyRequiredAmountAndAllowance(smartWallet, _sub.subData);
         }
 
-        // check AaveV3 leverage management, repay on price strategies and close strategies for all chains. We don't check for boost on price (BoP), as we want to always allow it. If debt is 0, BoP will open a leveraged position on price.
-        if (
-            strategyId.isAaveV3LeverageManagementStrategy() || strategyId.isAaveV3RepayOnPriceStrategy()
-                || strategyId.isAaveV3CloseStrategy()
-        ) {
+        // check AaveV3 leverage management and close strategies for all chains. We don't check for boost on price (BoP), as we want to always allow it. If debt is 0, BoP will open a leveraged position on price.
+        if (strategyId.isAaveV3LeverageManagementStrategy() || strategyId.isAaveV3CloseStrategy()) {
             return _verifyAaveV3MinDebtPosition(smartWallet);
+        }
+
+        // check for minDebt but also check if targetRatio is over startRatio
+        if (strategyId.isAaveV3RepayOnPriceStrategy()) {
+            return _verifyAaveV3RepayOnPrice(_sub, smartWallet);
         }
 
         // check Spark leverage management for only mainnet deployment
@@ -243,6 +253,20 @@ contract StrategyTriggerViewNoRevert is StrategyModel, CoreHelper, CheckWalletTy
         IPoolV3 lendingPool = IPoolV3(IPoolAddressesProvider(DEFAULT_AAVE_MARKET).getPool());
         (, uint256 totalDebtUSD,,,,) = lendingPool.getUserAccountData(_smartWallet);
         return _hasEnoughMinDebtInUSD(totalDebtUSD) ? TriggerStatus.TRUE : TriggerStatus.FALSE;
+    }
+
+    function _verifyAaveV3RepayOnPrice(StrategySub memory _sub, address _smartWallet)
+        public
+        view
+        returns (TriggerStatus)
+    {
+        TriggerStatus hasMinDebt = _verifyAaveV3MinDebtPosition(_smartWallet);
+        if (hasMinDebt != TriggerStatus.TRUE) return hasMinDebt;
+
+        uint256 targetRatio = uint256(_sub.subData[5]);
+        address market = (address(uint160(uint256(_sub.subData[4]))));
+        uint256 startRatio = getRatio(market, _smartWallet);
+        return targetRatio > startRatio ? TriggerStatus.TRUE : TriggerStatus.FALSE;
     }
 
     function _verifySparkMinDebtPosition(address _smartWallet) internal view returns (TriggerStatus) {

--- a/contracts/views/strategy/StrategyTriggerViewNoRevert.sol
+++ b/contracts/views/strategy/StrategyTriggerViewNoRevert.sol
@@ -273,7 +273,7 @@ contract StrategyTriggerViewNoRevert is
         returns (TriggerStatus)
     {
         TriggerStatus hasMinDebt = _verifyAaveV3MinDebtPosition(_smartWallet);
-        if (hasMinDebt != TriggerStatus.TRUE) return hasMinDebt;
+        if (hasMinDebt != TriggerStatus.TRUE) return TriggerStatus.FALSE;
 
         uint256 targetRatio = uint256(_sub.subData[5]);
         address market = (address(uint160(uint256(_sub.subData[4]))));

--- a/test-sol/triggers/StrategyTriggerViewNoRevert.t.sol
+++ b/test-sol/triggers/StrategyTriggerViewNoRevert.t.sol
@@ -133,9 +133,11 @@ contract TestStrategyTriggerViewNoRevert is BaseTest, StrategyTriggerViewNoRever
             "trigger status should be true"
         );
 
-        address walletWithNotEnoughDebt = 0x486c0bE444b63898Cca811654709f7D9e036Dc4E;
+        // Now set targetRatio very low so targetRatio <= startRatio and the trigger should be FALSE
+        sub.subData[5] = bytes32(uint256(11e17)); // 110%
+
         assertEq(
-            uint256(_verifyAaveV3MinDebtPosition(walletWithNotEnoughDebt)),
+            uint256(this.checkTriggers(sub, triggerData, walletWithEnoughDebt)),
             uint256(TriggerStatus.FALSE),
             "trigger status should be false"
         );

--- a/test-sol/triggers/StrategyTriggerViewNoRevert.t.sol
+++ b/test-sol/triggers/StrategyTriggerViewNoRevert.t.sol
@@ -104,6 +104,43 @@ contract TestStrategyTriggerViewNoRevert is BaseTest, StrategyTriggerViewNoRever
         );
     }
 
+    // AaveV3RepayOnPrice
+    function test_verifyAaveV3RepayOnPriceConditions() public {
+        //vm.warp(1748518160);
+        address walletWithEnoughDebt = 0x60F5d62E26A52B034DE02182689CC6200de7fD29;
+
+        bytes32[] memory subData = new bytes32[](7);
+        subData[0] = bytes32(uint256(uint160(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2))); // WETH
+        subData[1] = bytes32(0);
+        subData[2] = bytes32(uint256(uint160(0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48))); // USDC
+        subData[3] = bytes32(uint256(3));
+        subData[4] = bytes32(uint256(uint160(0x2f39d218133AFaB8F2B819B1066c7E434Ad94E9e))); // Aave V3 Pool Addresses Provider
+        subData[5] = bytes32(uint256(0x056bc75e2d63100000)); // Target ratio (1e20)
+        subData[6] = bytes32(0);
+
+        // Initialize triggerData array properly
+        bytes[] memory triggerData = new bytes[](1);
+        triggerData[0] =
+            hex"000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb4800000000000000000000000000000000000000000000000000000073404c96000000000000000000000000000000000000000000000000000000000000000001";
+
+        // Create StrategySub struct
+        StrategySub memory sub =
+            StrategySub({strategyOrBundleId: 37, isBundle: true, triggerData: triggerData, subData: subData});
+
+        assertEq(
+            uint256(this.checkTriggers(sub, triggerData, walletWithEnoughDebt)),
+            uint256(TriggerStatus.TRUE),
+            "trigger status should be true"
+        );
+
+        address walletWithNotEnoughDebt = 0x486c0bE444b63898Cca811654709f7D9e036Dc4E;
+        assertEq(
+            uint256(_verifyAaveV3MinDebtPosition(walletWithNotEnoughDebt)),
+            uint256(TriggerStatus.FALSE),
+            "trigger status should be false"
+        );
+    }
+
     // Spark
     function test_verifySparkLeverageManagementConditions() public view {
         address walletWithEnoughDebt = 0xc0c790F61a1721B70F0D4b1Aa1133687Fa3fd900;


### PR DESCRIPTION
### Summary

Add ratio check for Aave v3 repay on price in StrategyTriggerViewNoRevert

### Type of change
- [x] Breaking Change - A change that is not backward-compatible.
- [ ] New Feature - A change that adds functionality.
- [ ] Tweak - A change that modifies existing features.
- [ ] Bugfix - A change that resolves an issue.

### Details

`StrategyTriggerViewNoRevert` will not trigger aave v3 repay on price strategy if `targetRatio` is not larger than `startRatio`

### Checks
  #### For New Contracts
  - [ ] Does the new contract have tests?
  - [ ] Does the contract contain all the NatSpec needed (`@title`, `@notice`, `@param`, etc.)?
  - [ ] Is the contract deployed and the address added to the JSON file?
  - [ ] If the contract is registered, is the waitPeriod set correctly?
  - [ ] Is the contract verified and added to the Tenderly dashboard?
  - [ ] Is documentation written for the corresponding DFS action and added to GitBook?
  
  #### For Modifications to Existing Contracts
  - [x] If there were existing tests for the contract, are they adapted for the change and executed?
  - [ ] Is the contract redeployed and added to the JSON file?
  - [ ] If the contract is registered, is the waitPeriod set correctly?
  - [ ] Is the contract verified and added to the Tenderly dashboard?
  - [ ] If some parameters were changed and a breaking change was introduced, is the documentation updated on GitBook?
  
  #### For Strategies
  - [ ] Are new tests added for the strategy?
  - [ ] Is the strategy deployed and added to the JSON file?

### References
_Link any existing PRs, such as SDK PRs related to this PR, or any additional references._
