### PR TITLE
improvement: spark refferal code

### DIFF
--- a/addresses/mainnet.json
+++ b/addresses/mainnet.json
@@ -1807,14 +1807,17 @@
     },
     {
         "name": "SparkSupply",
-        "address": "0xcb4505a5ED92e405BF1F5cD7C791B15c4564AAe9",
+        "address": "0xD10608B45718437082B9aF5DdC498080ad63Ac9E",
         "id": "0x92e0c47c",
         "path": "contracts/actions/spark/SparkSupply.sol",
-        "version": "1.0.1",
+        "version": "1.0.2",
         "inRegistry": true,
         "changeTime": "86400",
         "registryIds": [],
-        "history": ["0x9e1d7AAA55D83D36d55BF11cAe4d922aF52B6eF0"]
+        "history": [
+            "0xcb4505a5ED92e405BF1F5cD7C791B15c4564AAe9",
+            "0x9e1d7AAA55D83D36d55BF11cAe4d922aF52B6eF0"
+        ]
     },
     {
         "name": "SparkSPKClaim",
@@ -1884,14 +1887,16 @@
     },
     {
         "name": "SparkBorrow",
-        "address": "0x3E2C366065bA0f6f9936C2C6A802D72F250b27AA",
+        "address": "0x7a0207c1b5864B41629abBA4137b82a69F21F34d",
         "id": "0x9bc097ab",
         "path": "contracts/actions/spark/SparkBorrow.sol",
         "version": "1.0.1",
         "inRegistry": true,
         "changeTime": "86400",
         "registryIds": [],
-        "history": []
+        "history": [
+            "0x3E2C366065bA0f6f9936C2C6A802D72F250b27AA"
+        ]
     },
     {
         "name": "AaveV3ClaimRewards",

--- a/contracts/actions/spark/helpers/SparkHelper.sol
+++ b/contracts/actions/spark/helpers/SparkHelper.sol
@@ -10,7 +10,7 @@ import { ISparkPoolAddressesProvider } from "../../../interfaces/spark/ISparkPoo
 /// @title Utility functions and data used in Spark actions
 contract SparkHelper is MainnetSparkAddresses {
     
-    uint16 public constant SPARK_REFERRAL_CODE = 0;
+    uint16 public constant SPARK_REFERRAL_CODE = 64;
     
     
     /// @notice Returns the lending pool contract of the specified market


### PR DESCRIPTION
### Summary

Change referral code to 64.
Redeploy `SparkSupply` & `SparkBorrow`

### Type of change
- [ ] Breaking Change - A change that is not backward-compatible.
- [ ] New Feature - A change that adds functionality.
- [X] Tweak - A change that modifies existing features.
- [ ] Bugfix - A change that resolves an issue.

### Checks
  #### For Modifications to Existing Contracts
  - [ ] If there were existing tests for the contract, are they adapted for the change and executed?
  - [X] Is the contract redeployed and added to the JSON file?
  - [ ] If the contract is registered, is the waitPeriod set correctly?
  - [ ] Is the contract verified and added to the Tenderly dashboard?
  - [ ] If some parameters were changed and a breaking change was introduced, is the documentation updated on GitBook?
  
### References
_Link any existing PRs, such as SDK PRs related to this PR, or any additional references._
