### PR TITLE
test: fix summerfi unsub test by hardcoding block number

### DIFF
--- a/test-sol/actions/summerfi/SummerfiUnsubV2.t.sol
+++ b/test-sol/actions/summerfi/SummerfiUnsubV2.t.sol
@@ -36,7 +36,7 @@ contract SummerfiUnsubV2Test is BaseTest, ActionsUtils, RegistryUtils, SFProxyUt
                                   SETUP FUNCTION
     //////////////////////////////////////////////////////////////////////////*/
     function setUp() public override {
-        forkMainnetLatest();
+        forkMainnet("SummerfiUnsubV2");
 
         cut = new SummerfiUnsubV2();
         recipeExecutor = new RecipeExecutor();

--- a/test-sol/config/config.json
+++ b/test-sol/config/config.json
@@ -21,6 +21,7 @@
     "LiquityV2Automation": { "blockNumber": 22539730 },
     "UmbrellaStake": { "blockNumber": 22644898 },
     "UmbrellaUnstake": { "blockNumber": 22644898 },
+    "SummerfiUnsubV2": { "blockNumber": 24246520 },
     "AaveV3": {
         "lightTesting": false,
         "lightPairs": [{ "supplyAsset": "WETH", "borrowAsset": "DAI" }],


### PR DESCRIPTION
### Summary

Hardcode block number for SummerfiUnsubV2 tests. User un-subbed in the meantime

### Type of change

- [ ] New Feature - A change that adds functionality.
- [ ] Bugfix - A change that resolves an issue.
- [ ] Tweak - A change that modifies existing features.
- [ ] Refactor - Code improvements without changing behavior.
- [ ] Performance - Optimizations for gas or execution efficiency.
- [ ] Documentation - Updates to docs, comments, or NatSpec.
- [x] Tests - Adding or updating test coverage.
- [ ] Chore - Maintenance, dependencies, CI/CD, deployments or tooling updates.

### Details

_Provide any additional details if needed._

### References

_Link any existing PRs, such as SDK PRs related to this PR, or any additional references._

### Checks

#### For New Contracts

- [ ] Does the new contract have tests?
- [ ] Does the contract contain all the NatSpec needed (`@title`, `@notice`, `@param`, etc.)?
- [ ] Is the contract deployed and the address added to the JSON file?
- [ ] If the contract is registered, is the waitPeriod set correctly?
- [ ] Is the contract verified and added to the Tenderly dashboard?
- [ ] Is documentation written for the corresponding DFS action and added to GitBook?

#### For Modifications to Existing Contracts

- [ ] If there were existing tests for the contract, are they adapted for the change and executed?
- [ ] Is the contract redeployed and added to the JSON file?
- [ ] If the contract is registered, is the waitPeriod set correctly?
- [ ] Is the contract verified and added to the Tenderly dashboard?
- [ ] If some parameters were changed and a breaking change was introduced, is the documentation updated on GitBook?

#### For Strategies

- [ ] Are new tests added for the strategy?
- [ ] Is the strategy deployed and added to the JSON file?
