### PR TITLE
fix: aave v2 view REN price

### DIFF
--- a/addresses/mainnet.json
+++ b/addresses/mainnet.json
@@ -815,14 +815,16 @@
     },
     {
         "name": "AaveView",
-        "address": "0xD0bA40A400f9e045D54978E3B78Cd9aD9FA92144",
+        "address": "0x792c56838Ab06015da7E298e4bD2Cc31248a18Aa",
         "id": "0x0a55b48c",
         "path": "contracts/views/AaveView.sol",
-        "version": "1.0.2",
+        "version": "1.0.4",
         "inRegistry": false,
         "changeTime": 0,
         "registryIds": [],
         "history": [
+            "0x6102E50F88f039976bd1909a9CC368c7dd1d1A1d",
+            "0xD0bA40A400f9e045D54978E3B78Cd9aD9FA92144",
             "0xf585d53f568d226449a94d48c4ea122cdeffe52d",
             "0xEDf1087544a01596b70Da746F861B878F245B08f"
         ]

--- a/contracts/actions/aave/helpers/MainnetAaveAddresses.sol
+++ b/contracts/actions/aave/helpers/MainnetAaveAddresses.sol
@@ -8,4 +8,5 @@ contract MainnetAaveAddresses {
     address internal constant DYDX_FL_FEE_FAUCET = 0x47f159C90850D5cE09E21F931d504536840f34b4;
     address internal constant DEFAULT_AAVE_V2_MARKET = 0xB53C1a33016B2DC2fF3653530bfF1848a515c8c5;
     address internal constant AAVE_TOKEN_ADDR = 0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9;
+    address internal constant REN_TOKEN_ADDR = 0x408e41876cCCDC0F92210600ef50372656052a38;
 }

--- a/contracts/views/AaveView.sol
+++ b/contracts/views/AaveView.sol
@@ -27,6 +27,8 @@ contract AaveView is AaveHelper, DSMath {
         0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0000FFFFFFFFFFFFFFFF; // prettier-ignore
     uint256 constant RESERVE_FACTOR_START_BIT_POSITION = 64;
 
+    address constant REN_ADDRESS_MAINNET = 0x408e41876cCCDC0F92210600ef50372656052a38;
+
     using TokenUtils for address;
     using WadRayMath for uint256;
 
@@ -212,11 +214,16 @@ contract AaveView is AaveHelper, DSMath {
             (, uint256 ltv,,,,,,,,) = dataProvider.getReserveConfigurationData(_tokenAddresses[i]);
             (address aToken,,) = dataProvider.getReserveTokensAddresses(_tokenAddresses[i]);
 
+            uint256 price = 0;
+            if (_tokenAddresses[i] != REN_ADDRESS_MAINNET) {
+                price = IPriceOracleGetterAave(priceOracleAddress).getAssetPrice(_tokenAddresses[i]);
+            }
+
             tokens[i] = TokenInfo({
                 aTokenAddress: aToken,
                 underlyingTokenAddress: _tokenAddresses[i],
                 collateralFactor: ltv,
-                price: IPriceOracleGetterAave(priceOracleAddress).getAssetPrice(_tokenAddresses[i])
+                price: price
             });
         }
     }
@@ -250,7 +257,10 @@ contract AaveView is AaveHelper, DSMath {
 
         (address aToken,,) = _dataProvider.getReserveTokensAddresses(_token);
 
-        uint256 price = IPriceOracleGetterAave(_priceOracleAddress).getAssetPrice(_token);
+        uint256 price = 0;
+        if (_token != REN_ADDRESS_MAINNET) {
+            price = IPriceOracleGetterAave(_priceOracleAddress).getAssetPrice(_token);
+        }
 
         _tokenInfo = TokenInfoFull({
             aTokenAddress: aToken,
@@ -331,7 +341,11 @@ contract AaveView is AaveHelper, DSMath {
                 uint256 borrowsVariable,,,,,,
                 bool usageAsCollateralEnabled
             ) = dataProvider.getUserReserveData(reserve, _user);
-            uint256 price = IPriceOracleGetterAave(priceOracleAddress).getAssetPrice(reserve);
+
+            uint256 price = 0;
+            if (reserve != REN_ADDRESS_MAINNET) {
+                price = IPriceOracleGetterAave(priceOracleAddress).getAssetPrice(reserve);
+            }
 
             if (aTokenBalance > 0) {
                 uint256 userTokenBalanceEth =

--- a/contracts/views/AaveView.sol
+++ b/contracts/views/AaveView.sol
@@ -27,8 +27,6 @@ contract AaveView is AaveHelper, DSMath {
         0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0000FFFFFFFFFFFFFFFF; // prettier-ignore
     uint256 constant RESERVE_FACTOR_START_BIT_POSITION = 64;
 
-    address constant REN_ADDRESS_MAINNET = 0x408e41876cCCDC0F92210600ef50372656052a38;
-
     using TokenUtils for address;
     using WadRayMath for uint256;
 
@@ -215,7 +213,7 @@ contract AaveView is AaveHelper, DSMath {
             (address aToken,,) = dataProvider.getReserveTokensAddresses(_tokenAddresses[i]);
 
             uint256 price = 0;
-            if (_tokenAddresses[i] != REN_ADDRESS_MAINNET) {
+            if (_tokenAddresses[i] != REN_TOKEN_ADDR) {
                 price = IPriceOracleGetterAave(priceOracleAddress).getAssetPrice(_tokenAddresses[i]);
             }
 
@@ -258,7 +256,7 @@ contract AaveView is AaveHelper, DSMath {
         (address aToken,,) = _dataProvider.getReserveTokensAddresses(_token);
 
         uint256 price = 0;
-        if (_token != REN_ADDRESS_MAINNET) {
+        if (_token != REN_TOKEN_ADDR) {
             price = IPriceOracleGetterAave(_priceOracleAddress).getAssetPrice(_token);
         }
 
@@ -343,7 +341,7 @@ contract AaveView is AaveHelper, DSMath {
             ) = dataProvider.getUserReserveData(reserve, _user);
 
             uint256 price = 0;
-            if (reserve != REN_ADDRESS_MAINNET) {
+            if (reserve != REN_TOKEN_ADDR) {
                 price = IPriceOracleGetterAave(priceOracleAddress).getAssetPrice(reserve);
             }
 

--- a/test-sol/views/AaveView.t.sol
+++ b/test-sol/views/AaveView.t.sol
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity =0.8.24;
+
+import { BaseTest } from "../utils/BaseTest.sol";
+import { AaveView } from "../../contracts/views/AaveView.sol";
+import {
+    IAaveProtocolDataProviderV2
+} from "../../contracts/interfaces/protocols/aaveV2/IAaveProtocolDataProviderV2.sol";
+import {
+    ILendingPoolAddressesProviderV2
+} from "../../contracts/interfaces/protocols/aaveV2/ILendingPoolAddressesProviderV2.sol";
+
+contract TestAaveView is BaseTest {
+    AaveView cut;
+
+    /// @dev Aave V2 LendingPoolAddressesProvider on mainnet
+    address internal constant AAVE_V2_MARKET = 0xB53C1a33016B2DC2fF3653530bfF1848a515c8c5;
+    address internal constant USER = 0xECf1839269f9240F9b897e38C092b1740A4c316D;
+
+    address internal constant STETH = 0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84;
+    address internal constant REN = 0x408e41876cCCDC0F92210600ef50372656052a38;
+
+    bytes32 internal constant DATA_PROVIDER_ID =
+        0x0100000000000000000000000000000000000000000000000000000000000000;
+
+    function setUp() public override {
+        forkMainnetLatest();
+        cut = new AaveView();
+    }
+
+    function test_getLoanData_does_not_revert() public view {
+        AaveView.LoanData memory data = cut.getLoanData(AAVE_V2_MARKET, USER);
+        assertEq(data.user, USER);
+    }
+
+    function test_getTokensInfo_stETH_and_REN() public view {
+        address[] memory tokens = new address[](2);
+        tokens[0] = STETH;
+        tokens[1] = REN;
+
+        AaveView.TokenInfo[] memory infos = cut.getTokensInfo(AAVE_V2_MARKET, tokens);
+
+        assertEq(infos.length, 2);
+        assertEq(infos[0].underlyingTokenAddress, STETH);
+        assertEq(infos[1].underlyingTokenAddress, REN);
+        assertTrue(infos[0].price > 0);
+        assertTrue(infos[1].price == 0);
+    }
+
+    function test_getTokenInfoFull_stETH() public view {
+        address dataProviderAddr =
+            ILendingPoolAddressesProviderV2(AAVE_V2_MARKET).getAddress(DATA_PROVIDER_ID);
+        address priceOracle = ILendingPoolAddressesProviderV2(AAVE_V2_MARKET).getPriceOracle();
+        IAaveProtocolDataProviderV2 dataProvider = IAaveProtocolDataProviderV2(dataProviderAddr);
+
+        AaveView.TokenInfoFull memory info = cut.getTokenInfoFull(dataProvider, priceOracle, STETH);
+
+        assertEq(info.underlyingTokenAddress, STETH);
+        assertTrue(info.price > 0);
+        assertTrue(info.totalSupply > 0);
+    }
+
+    function test_getTokenInfoFull_REN() public view {
+        address dataProviderAddr =
+            ILendingPoolAddressesProviderV2(AAVE_V2_MARKET).getAddress(DATA_PROVIDER_ID);
+        address priceOracle = ILendingPoolAddressesProviderV2(AAVE_V2_MARKET).getPriceOracle();
+        IAaveProtocolDataProviderV2 dataProvider = IAaveProtocolDataProviderV2(dataProviderAddr);
+
+        AaveView.TokenInfoFull memory info = cut.getTokenInfoFull(dataProvider, priceOracle, REN);
+
+        assertEq(info.underlyingTokenAddress, REN);
+        assertTrue(info.price == 0);
+    }
+}


### PR DESCRIPTION
### Summary

Chainlink oracle stopped working for REN token and started reverting. Skip price fetching for REN token and hardcode it to 0. 

### Type of change

- [ ] New Feature - A change that adds functionality.
- [x] Bugfix - A change that resolves an issue.
- [ ] Tweak - A change that modifies existing features.
- [ ] Refactor - Code improvements without changing behavior.
- [ ] Performance - Optimizations for gas or execution efficiency.
- [ ] Documentation - Updates to docs, comments, or NatSpec.
- [ ] Tests - Adding or updating test coverage.
- [ ] Chore - Maintenance, dependencies, CI/CD, deployments or tooling updates.

### Details

_Provide any additional details if needed._

### References

_Link any existing PRs, such as SDK PRs related to this PR, or any additional references._

### Checks

#### For New Contracts

- [ ] Does the new contract have tests?
- [ ] Does the contract contain all the NatSpec needed (`@title`, `@notice`, `@param`, etc.)?
- [ ] Is the contract deployed and the address added to the JSON file?
- [ ] If the contract is registered, is the waitPeriod set correctly?
- [ ] Is the contract verified and added to the Tenderly dashboard?
- [ ] Is documentation written for the corresponding DFS action and added to GitBook?

#### For Modifications to Existing Contracts

- [x] If there were existing tests for the contract, are they adapted for the change and executed?
- [ ] Is the contract redeployed and added to the JSON file?
- [ ] If the contract is registered, is the waitPeriod set correctly?
- [ ] Is the contract verified and added to the Tenderly dashboard?
- [ ] If some parameters were changed and a breaking change was introduced, is the documentation updated on GitBook?

#### For Strategies

- [ ] Are new tests added for the strategy?
- [ ] Is the strategy deployed and added to the JSON file?
