### PR TITLE
feat: add LTV0 check in StrategyTriggerViewNoRevert

### DIFF
--- a/addresses/arbitrum.json
+++ b/addresses/arbitrum.json
@@ -337,14 +337,15 @@
     },
     {
         "name": "StrategyTriggerViewNoRevert",
-        "address": "0x6520e22b6e147297D9a891678860931353FFeafB",
+        "address": "0x67ED79B0116071F805A6A0d642DC0757E6029492",
         "id": "0x37a21cb5",
         "path": "contracts/views/strategy/StrategyTriggerViewNoRevert.sol",
-        "version": "1.0.4",
+        "version": "1.0.5",
         "inRegistry": false,
         "changeTime": 0,
         "registryIds": [],
         "history": [
+            "0x6520e22b6e147297D9a891678860931353FFeafB",
             "0x966e357706C31B8b56E89Da68A487646fD16cF10",
             "0xea74835820fEBdF7bE8837Fa4D0Cd9CC34054f4F",
             "0x90f167964c0B265E2Ac9b9A4BCc230b0E163ce18",

--- a/addresses/base.json
+++ b/addresses/base.json
@@ -1169,14 +1169,15 @@
     },
     {
         "name": "StrategyTriggerViewNoRevert",
-        "address": "0x95716E3724b3aFa1308a078Ddd5D52a3d0991915",
+        "address": "0x2D2208e64dE3A3B402b5675aBd43bAEbe2055952",
         "id": "0x37a21cb5",
         "path": "contracts/views/strategy/StrategyTriggerViewNoRevert.sol",
-        "version": "1.0.4",
+        "version": "1.0.5",
         "inRegistry": false,
         "changeTime": 0,
         "registryIds": [],
         "history": [
+            "0x95716E3724b3aFa1308a078Ddd5D52a3d0991915",
             "0x0D8aa257cF350C95730Ab5125A55612af5aaAA89",
             "0x1D0A79E1deE64193623595295d43BA7ae18a86d8",
             "0x8f961C95FA207657E39a7027dFE9B4A44E1E9D4c",

--- a/addresses/mainnet.json
+++ b/addresses/mainnet.json
@@ -451,14 +451,15 @@
     },
     {
         "name": "StrategyTriggerViewNoRevert",
-        "address": "0xEEfc5edc8dEDeeD92834469F2da3e2D415731137",
+        "address": "0x6f4bD4F45cA40EB95f070A9A4AeC9e47cEF05a3E",
         "id": "0x37a21cb5",
         "path": "contracts/views/strategy/StrategyTriggerViewNoRevert.sol",
-        "version": "1.0.4",
+        "version": "1.0.5",
         "inRegistry": false,
         "changeTime": 0,
         "registryIds": [],
         "history": [
+            "0xEEfc5edc8dEDeeD92834469F2da3e2D415731137",
             "0x395079428c66C1AB0144057366c7493C92326860",
             "0x40F282Eb32995A1763619dd4200d19e79BC61CE8",
             "0xe3d31D3e005B55e72B7c3ECE4E0e2a5Aee2B8C63",

--- a/addresses/optimism.json
+++ b/addresses/optimism.json
@@ -327,14 +327,15 @@
     },
     {
         "name": "StrategyTriggerViewNoRevert",
-        "address": "0xE8Ca11025fC373fb7a42e92eD374f1B8EE2B6F2a",
+        "address": "0x2BF8A23ECfe84179663e0c6Dfb328cf92b18d561",
         "id": "0x37a21cb5",
         "path": "contracts/views/strategy/StrategyTriggerViewNoRevert.sol",
-        "version": "1.0.4",
+        "version": "1.0.5",
         "inRegistry": false,
         "changeTime": 0,
         "registryIds": [],
         "history": [
+            "0xE8Ca11025fC373fb7a42e92eD374f1B8EE2B6F2a",
             "0xbFe9e11963228D82C71F974D0Ff8648569687841",
             "0x0348bc9c79779f4195971B3348Fc0c32C91e19e9",
             "0x05a235fE5b0343c9d0B77E1AE59A9198328A7b37",

--- a/contracts/views/strategy/StrategyTriggerViewNoRevert.sol
+++ b/contracts/views/strategy/StrategyTriggerViewNoRevert.sol
@@ -2,12 +2,12 @@
 pragma solidity =0.8.24;
 
 import { IPoolV3 } from "../../interfaces/protocols/aaveV3/IPoolV3.sol";
-import {
-    IPoolAddressesProvider
-} from "../../interfaces/protocols/aaveV3/IPoolAddressesProvider.sol";
+import { IPoolAddressesProvider } from
+    "../../interfaces/protocols/aaveV3/IPoolAddressesProvider.sol";
 import { IERC20 } from "../../interfaces/token/IERC20.sol";
 import { ITrigger } from "../../interfaces/core/ITrigger.sol";
 import { IDFSRegistry } from "../../interfaces/core/IDFSRegistry.sol";
+import { DataTypes } from "../../interfaces/protocols/aaveV3/DataTypes.sol";
 
 import { SmartWalletUtils } from "../../utils/SmartWalletUtils.sol";
 import { BundleStorage } from "../../core/strategy/BundleStorage.sol";
@@ -20,7 +20,12 @@ import { AaveV3Helper } from "../../actions/aaveV3/helpers/AaveV3Helper.sol";
 
 /// @title StrategyTriggerViewNoRevert - Helper contract to check whether a trigger is triggered or not for a given sub.
 /// @dev This contract is designed to avoid reverts from checking triggers.
-contract StrategyTriggerViewNoRevert is StrategyModel, CoreHelper, SmartWalletUtils, AaveV3Helper {
+contract StrategyTriggerViewNoRevert is
+    StrategyModel,
+    CoreHelper,
+    SmartWalletUtils,
+    AaveV3Helper
+{
     IDFSRegistry public constant registry = IDFSRegistry(REGISTRY_ADDR);
 
     address internal constant DEFAULT_SPARK_MARKET_MAINNET =
@@ -124,10 +129,8 @@ contract StrategyTriggerViewNoRevert is StrategyModel, CoreHelper, SmartWalletUt
 
         for (uint256 i = 0; i < triggerIds.length; i++) {
             triggerAddr = registry.getAddr(triggerIds[i]);
-            try ITrigger(triggerAddr)
-                .isTriggered(_triggerCallData[i], _sub.triggerData[i]) returns (
-                bool isTriggered
-            ) {
+            try ITrigger(triggerAddr).isTriggered(_triggerCallData[i], _sub.triggerData[i])
+            returns (bool isTriggered) {
                 if (!isTriggered) {
                     return TriggerStatus.FALSE;
                 }
@@ -141,8 +144,13 @@ contract StrategyTriggerViewNoRevert is StrategyModel, CoreHelper, SmartWalletUt
             return _tryToVerifyRequiredAmountAndAllowance(smartWallet, _sub.subData);
         }
 
-        // check AaveV3 leverage management and close strategies for all chains
-        if (strategyId.isAaveV3LeverageManagementStrategy() || strategyId.isAaveV3CloseStrategy()) {
+        // check min debt and ltv0 for AaveV3 leverage management strategies
+        if (strategyId.isAaveV3LeverageManagementStrategy()) {
+            return _tryToVerifyAaveV3Conditions(smartWallet);
+        }
+
+        // check min debt for AaveV3 close strategies
+        if (strategyId.isAaveV3CloseStrategy()) {
             return _verifyAaveV3MinDebtPosition(smartWallet);
         }
 
@@ -157,10 +165,11 @@ contract StrategyTriggerViewNoRevert is StrategyModel, CoreHelper, SmartWalletUt
     /*//////////////////////////////////////////////////////////////
                               VERIFY LOGIC
     //////////////////////////////////////////////////////////////*/
-    function _tryToVerifyRequiredAmountAndAllowance(
-        address _smartWallet,
-        bytes32[] memory _subData
-    ) internal view returns (TriggerStatus) {
+    function _tryToVerifyRequiredAmountAndAllowance(address _smartWallet, bytes32[] memory _subData)
+        internal
+        view
+        returns (TriggerStatus)
+    {
         try this.verifyRequiredAmountAndAllowance(_smartWallet, _subData) returns (
             TriggerStatus status
         ) {
@@ -224,5 +233,89 @@ contract StrategyTriggerViewNoRevert is StrategyModel, CoreHelper, SmartWalletUt
         }
 
         return _userDebtInUSD >= MIN_DEBT_IN_USD_L2;
+    }
+
+    function _tryToVerifyAaveV3Conditions(address _smartWallet)
+        internal
+        view
+        returns (TriggerStatus)
+    {
+        try this.verifyAaveV3Conditions(_smartWallet) returns (TriggerStatus status) {
+            return status;
+        } catch {
+            return TriggerStatus.REVERT;
+        }
+    }
+
+    function verifyAaveV3Conditions(address _smartWallet) external view returns (TriggerStatus) {
+        // If not enough debt, return FALSE
+        if (_verifyAaveV3MinDebtPosition(_smartWallet) == TriggerStatus.FALSE) {
+            return TriggerStatus.FALSE;
+        }
+        // If any collateral is at 0% LTV, return FALSE
+        if (_verifyAaveV3Ltv0Position(_smartWallet) == TriggerStatus.FALSE) {
+            return TriggerStatus.FALSE;
+        }
+
+        // Otherwise, return TRUE
+        return TriggerStatus.TRUE;
+    }
+
+    function _verifyAaveV3Ltv0Position(address _smartWallet)
+        internal
+        view
+        returns (TriggerStatus)
+    {
+        IPoolV3 lendingPool = IPoolV3(IPoolAddressesProvider(DEFAULT_AAVE_MARKET).getPool());
+        address[] memory reserveList = lendingPool.getReservesList();
+        DataTypes.UserConfigurationMap memory userConfig =
+            lendingPool.getUserConfiguration(_smartWallet);
+
+        // Emode info
+        uint256 eModeId = lendingPool.getUserEMode(_smartWallet);
+        bool isInEmode = eModeId != 0;
+        uint128 emodeCollateralBitmap;
+        uint128 emodeLtvZeroBitmap;
+        if (isInEmode) {
+            emodeCollateralBitmap = lendingPool.getEModeCategoryCollateralBitmap(uint8(eModeId));
+            emodeLtvZeroBitmap = lendingPool.getEModeCategoryLtvzeroBitmap(uint8(eModeId));
+        }
+
+        for (uint256 i = 0; i < reserveList.length; ++i) {
+            DataTypes.ReserveData memory reserveData = lendingPool.getReserveData(reserveList[i]);
+            if (!_isUsingAsCollateral(userConfig, reserveData.id)) continue;
+
+            bool isLtvZero;
+            if (isInEmode && _isAssetInBitmap(reserveData.id, emodeCollateralBitmap)) {
+                isLtvZero = _isAssetInBitmap(reserveData.id, emodeLtvZeroBitmap);
+            } else {
+                isLtvZero = _isReserveLtvZero(reserveData.configuration);
+            }
+
+            if (isLtvZero) return TriggerStatus.FALSE;
+        }
+
+        return TriggerStatus.TRUE;
+    }
+
+    function _isUsingAsCollateral(
+        DataTypes.UserConfigurationMap memory _userConfig,
+        uint256 _reserveIndex
+    ) internal pure returns (bool) {
+        unchecked {
+            return (_userConfig.data >> ((_reserveIndex << 1) + 1)) & 1 != 0;
+        }
+    }
+
+    function _isAssetInBitmap(uint256 _assetId, uint128 _bitmap) internal pure returns (bool) {
+        return (_bitmap & (uint128(1) << _assetId)) != 0;
+    }
+
+    function _isReserveLtvZero(DataTypes.ReserveConfigurationMap memory _reserveConfig)
+        internal
+        pure
+        returns (bool)
+    {
+        return (_reserveConfig.data & uint256(type(uint16).max)) == 0;
     }
 }

--- a/contracts/views/strategy/StrategyTriggerViewNoRevert.sol
+++ b/contracts/views/strategy/StrategyTriggerViewNoRevert.sol
@@ -28,6 +28,9 @@ contract StrategyTriggerViewNoRevert is
 {
     IDFSRegistry public constant registry = IDFSRegistry(REGISTRY_ADDR);
 
+    uint256 internal constant LTV_MASK =
+        0x000000000000000000000000000000000000000000000000000000000000FFFF;
+
     address internal constant DEFAULT_SPARK_MARKET_MAINNET =
         0x02C3eA4e34C0cBd694D2adFa2c690EECbC1793eE;
 
@@ -286,8 +289,8 @@ contract StrategyTriggerViewNoRevert is
             if (!_isUsingAsCollateral(userConfig, reserveData.id)) continue;
 
             bool isLtvZero;
-            if (isInEmode && _isAssetInBitmap(reserveData.id, emodeCollateralBitmap)) {
-                isLtvZero = _isAssetInBitmap(reserveData.id, emodeLtvZeroBitmap);
+            if (isInEmode && _isReserveEnabledOnBitmap(emodeCollateralBitmap, reserveData.id)) {
+                isLtvZero = _isReserveEnabledOnBitmap(emodeLtvZeroBitmap, reserveData.id);
             } else {
                 isLtvZero = _isReserveLtvZero(reserveData.configuration);
             }
@@ -307,8 +310,14 @@ contract StrategyTriggerViewNoRevert is
         }
     }
 
-    function _isAssetInBitmap(uint256 _assetId, uint128 _bitmap) internal pure returns (bool) {
-        return (_bitmap & (uint128(1) << _assetId)) != 0;
+    function _isReserveEnabledOnBitmap(uint128 _bitmap, uint256 _reserveIndex)
+        internal
+        pure
+        returns (bool)
+    {
+        unchecked {
+            return (_bitmap >> _reserveIndex) & 1 != 0;
+        }
     }
 
     function _isReserveLtvZero(DataTypes.ReserveConfigurationMap memory _reserveConfig)
@@ -316,6 +325,6 @@ contract StrategyTriggerViewNoRevert is
         pure
         returns (bool)
     {
-        return (_reserveConfig.data & uint256(type(uint16).max)) == 0;
+        return (_reserveConfig.data & LTV_MASK) == 0;
     }
 }

--- a/contracts/views/strategy/StrategyTriggerViewNoRevert.sol
+++ b/contracts/views/strategy/StrategyTriggerViewNoRevert.sol
@@ -2,8 +2,9 @@
 pragma solidity =0.8.24;
 
 import { IPoolV3 } from "../../interfaces/protocols/aaveV3/IPoolV3.sol";
-import { IPoolAddressesProvider } from
-    "../../interfaces/protocols/aaveV3/IPoolAddressesProvider.sol";
+import {
+    IPoolAddressesProvider
+} from "../../interfaces/protocols/aaveV3/IPoolAddressesProvider.sol";
 import { IERC20 } from "../../interfaces/token/IERC20.sol";
 import { ITrigger } from "../../interfaces/core/ITrigger.sol";
 import { IDFSRegistry } from "../../interfaces/core/IDFSRegistry.sol";
@@ -20,12 +21,7 @@ import { AaveV3Helper } from "../../actions/aaveV3/helpers/AaveV3Helper.sol";
 
 /// @title StrategyTriggerViewNoRevert - Helper contract to check whether a trigger is triggered or not for a given sub.
 /// @dev This contract is designed to avoid reverts from checking triggers.
-contract StrategyTriggerViewNoRevert is
-    StrategyModel,
-    CoreHelper,
-    SmartWalletUtils,
-    AaveV3Helper
-{
+contract StrategyTriggerViewNoRevert is StrategyModel, CoreHelper, SmartWalletUtils, AaveV3Helper {
     IDFSRegistry public constant registry = IDFSRegistry(REGISTRY_ADDR);
 
     uint256 internal constant LTV_MASK =
@@ -132,8 +128,10 @@ contract StrategyTriggerViewNoRevert is
 
         for (uint256 i = 0; i < triggerIds.length; i++) {
             triggerAddr = registry.getAddr(triggerIds[i]);
-            try ITrigger(triggerAddr).isTriggered(_triggerCallData[i], _sub.triggerData[i])
-            returns (bool isTriggered) {
+            try ITrigger(triggerAddr)
+                .isTriggered(_triggerCallData[i], _sub.triggerData[i]) returns (
+                bool isTriggered
+            ) {
                 if (!isTriggered) {
                     return TriggerStatus.FALSE;
                 }
@@ -168,11 +166,10 @@ contract StrategyTriggerViewNoRevert is
     /*//////////////////////////////////////////////////////////////
                               VERIFY LOGIC
     //////////////////////////////////////////////////////////////*/
-    function _tryToVerifyRequiredAmountAndAllowance(address _smartWallet, bytes32[] memory _subData)
-        internal
-        view
-        returns (TriggerStatus)
-    {
+    function _tryToVerifyRequiredAmountAndAllowance(
+        address _smartWallet,
+        bytes32[] memory _subData
+    ) internal view returns (TriggerStatus) {
         try this.verifyRequiredAmountAndAllowance(_smartWallet, _subData) returns (
             TriggerStatus status
         ) {
@@ -264,17 +261,11 @@ contract StrategyTriggerViewNoRevert is
         return TriggerStatus.TRUE;
     }
 
-    function _verifyAaveV3Ltv0Position(address _smartWallet)
-        internal
-        view
-        returns (TriggerStatus)
-    {
+    function _verifyAaveV3Ltv0Position(address _smartWallet) internal view returns (TriggerStatus) {
         IPoolV3 lendingPool = IPoolV3(IPoolAddressesProvider(DEFAULT_AAVE_MARKET).getPool());
-        address[] memory reserveList = lendingPool.getReservesList();
         DataTypes.UserConfigurationMap memory userConfig =
             lendingPool.getUserConfiguration(_smartWallet);
-
-        // Emode info
+        // eMode info
         uint256 eModeId = lendingPool.getUserEMode(_smartWallet);
         bool isInEmode = eModeId != 0;
         uint128 emodeCollateralBitmap;
@@ -283,21 +274,30 @@ contract StrategyTriggerViewNoRevert is
             emodeCollateralBitmap = lendingPool.getEModeCategoryCollateralBitmap(uint8(eModeId));
             emodeLtvZeroBitmap = lendingPool.getEModeCategoryLtvzeroBitmap(uint8(eModeId));
         }
-
-        for (uint256 i = 0; i < reserveList.length; ++i) {
-            DataTypes.ReserveData memory reserveData = lendingPool.getReserveData(reserveList[i]);
-            if (!_isUsingAsCollateral(userConfig, reserveData.id)) continue;
-
-            bool isLtvZero;
-            if (isInEmode && _isReserveEnabledOnBitmap(emodeCollateralBitmap, reserveData.id)) {
-                isLtvZero = _isReserveEnabledOnBitmap(emodeLtvZeroBitmap, reserveData.id);
-            } else {
-                isLtvZero = _isReserveLtvZero(reserveData.configuration);
+        uint256 i = 0;
+        uint256 cachedUserConfig = userConfig.data;
+        while (cachedUserConfig != 0) {
+            // bits per reserve: [borrowingBit, collateralBit]
+            bool isEnabledAsCollateral = (cachedUserConfig & 2) != 0;
+            if (isEnabledAsCollateral) {
+                address asset = lendingPool.getReserveAddressById(uint16(i));
+                if (asset != address(0)) {
+                    DataTypes.ReserveConfigurationMap memory reserveConfig =
+                        lendingPool.getConfiguration(asset);
+                    bool isLtvZero;
+                    if (isInEmode && _isReserveEnabledOnBitmap(emodeCollateralBitmap, i)) {
+                        isLtvZero = _isReserveEnabledOnBitmap(emodeLtvZeroBitmap, i);
+                    } else {
+                        isLtvZero = _isReserveLtvZero(reserveConfig);
+                    }
+                    if (isLtvZero) return TriggerStatus.FALSE;
+                }
             }
-
-            if (isLtvZero) return TriggerStatus.FALSE;
+            cachedUserConfig = cachedUserConfig >> 2;
+            unchecked {
+                ++i;
+            }
         }
-
         return TriggerStatus.TRUE;
     }
 

--- a/foundry.toml
+++ b/foundry.toml
@@ -37,9 +37,10 @@ exclude_lints = [
     # "unsafe-cheatcode",
     # "erc20-unchecked-transfer",
     # "divide-before-multiply",
-    "unsafe-typecast",
-    "named-struct-fields",
-    "unwrapped-modifier-logic",
+    # ! Commented out due to foundry version
+    # "unsafe-typecast",
+    # "named-struct-fields",
+    # "unwrapped-modifier-logic",
     "asm-keccak256",
 
     "mixed-case-function",

--- a/test-sol/triggers/StrategyTriggerViewNoRevert.t.sol
+++ b/test-sol/triggers/StrategyTriggerViewNoRevert.t.sol
@@ -7,6 +7,11 @@ import { Addresses } from "../utils/Addresses.sol";
 import { SmartWallet } from "../utils/SmartWallet.sol";
 import { StrategyTriggerViewNoRevert } from
     "../../contracts/views/strategy/StrategyTriggerViewNoRevert.sol";
+import { AaveV3CollateralSwitch } from "../../contracts/actions/aaveV3/AaveV3CollateralSwitch.sol";
+import { IPoolV3 } from "../../contracts/interfaces/protocols/aaveV3/IPoolV3.sol";
+import { IPoolAddressesProvider } from
+    "../../contracts/interfaces/protocols/aaveV3/IPoolAddressesProvider.sol";
+import { IDSProxy } from "../../contracts/interfaces/DS/IDSProxy.sol";
 
 contract TestStrategyTriggerViewNoRevert is BaseTest, StrategyTriggerViewNoRevert {
     /*//////////////////////////////////////////////////////////////////////////
@@ -137,6 +142,39 @@ contract TestStrategyTriggerViewNoRevert is BaseTest, StrategyTriggerViewNoRever
             uint256(_verifyAaveV3Ltv0Position(walletWithLinkInEmode)),
             uint256(TriggerStatus.TRUE),
             "trigger status should be TRUE"
+        );
+    }
+
+    function test_verifyAaveV3Ltv0_afterDisablingLinkCollateral() public {
+        address walletWithLTV0Asset2 = 0x9495D189896FCb04e3d2E5bB102Ad76C6782c41A;
+        address walletOwner = 0x3745AF941FbBF3336aB21bB3a9853e75320382ab;
+        IPoolV3 lendingPool = IPoolV3(IPoolAddressesProvider(DEFAULT_AAVE_MARKET).getPool());
+        uint16 linkAssetId = lendingPool.getReserveData(Addresses.LINK_ADDR).id;
+        AaveV3CollateralSwitch collSwitch = new AaveV3CollateralSwitch();
+
+        uint16[] memory assetIds = new uint16[](1);
+        assetIds[0] = linkAssetId;
+        bool[] memory useAsCollateral = new bool[](1);
+        useAsCollateral[0] = false;
+
+        AaveV3CollateralSwitch.Params memory params = AaveV3CollateralSwitch.Params({
+            arrayLength: 1,
+            useDefaultMarket: true,
+            assetIds: assetIds,
+            useAsCollateral: useAsCollateral,
+            market: address(0)
+        });
+
+        vm.prank(walletOwner);
+        IDSProxy(payable(walletWithLTV0Asset2)).execute(
+            address(collSwitch),
+            abi.encodeWithSelector(collSwitch.executeActionDirect.selector, abi.encode(params))
+        );
+
+        assertEq(
+            uint256(_verifyAaveV3Ltv0Position(walletWithLTV0Asset2)),
+            uint256(TriggerStatus.TRUE),
+            "trigger status should be TRUE after using LINK as collateral is disabled"
         );
     }
 }

--- a/test-sol/triggers/StrategyTriggerViewNoRevert.t.sol
+++ b/test-sol/triggers/StrategyTriggerViewNoRevert.t.sol
@@ -5,9 +5,8 @@ pragma solidity =0.8.24;
 import { BaseTest } from "../utils/BaseTest.sol";
 import { Addresses } from "../utils/Addresses.sol";
 import { SmartWallet } from "../utils/SmartWallet.sol";
-import {
-    StrategyTriggerViewNoRevert
-} from "../../contracts/views/strategy/StrategyTriggerViewNoRevert.sol";
+import { StrategyTriggerViewNoRevert } from
+    "../../contracts/views/strategy/StrategyTriggerViewNoRevert.sol";
 
 contract TestStrategyTriggerViewNoRevert is BaseTest, StrategyTriggerViewNoRevert {
     /*//////////////////////////////////////////////////////////////////////////
@@ -21,7 +20,7 @@ contract TestStrategyTriggerViewNoRevert is BaseTest, StrategyTriggerViewNoRever
                                    SETUP FUNCTION
     //////////////////////////////////////////////////////////////////////////*/
     function setUp() public override {
-        forkMainnet("StrategyTriggerViewNoRevert");
+        forkMainnetLatest();
 
         wallet = new SmartWallet(bob);
         sender = wallet.owner();
@@ -85,7 +84,7 @@ contract TestStrategyTriggerViewNoRevert is BaseTest, StrategyTriggerViewNoRever
         );
     }
 
-    function test_verifyAaveV3LeverageManagementConditions() public view {
+    function test_verifyAaveV3MinDebtCondition() public view {
         //vm.warp(1748518160);
         address walletWithEnoughDebt = 0xaB5a28B6Ca2D1E12FE5AcC7341352d5032b74438;
         assertEq(
@@ -103,7 +102,7 @@ contract TestStrategyTriggerViewNoRevert is BaseTest, StrategyTriggerViewNoRever
     }
 
     function test_verifySparkLeverageManagementConditions() public view {
-        address walletWithEnoughDebt = 0xc0c790F61a1721B70F0D4b1Aa1133687Fa3fd900;
+        address walletWithEnoughDebt = 0x3a0DC3fC4b84E2427ced214C9CE858eA218E97d9;
         assertEq(
             uint256(_verifySparkMinDebtPosition(walletWithEnoughDebt)),
             uint256(TriggerStatus.TRUE),
@@ -115,6 +114,29 @@ contract TestStrategyTriggerViewNoRevert is BaseTest, StrategyTriggerViewNoRever
             uint256(_verifySparkMinDebtPosition(walletWithNotEnoughDebt)),
             uint256(TriggerStatus.FALSE),
             "trigger status should be false"
+        );
+    }
+
+    function test_verifyAaveV3Ltv0() public view {
+        address walletWithLTV0Asset = 0xeCA1395C29527b4CeA5AF5517138Ac01754bcfC8;
+        assertEq(
+            uint256(_verifyAaveV3Ltv0Position(walletWithLTV0Asset)),
+            uint256(TriggerStatus.FALSE),
+            "trigger status should be FALSE"
+        );
+
+        address walletWithLTV0Asset2 = 0x9495D189896FCb04e3d2E5bB102Ad76C6782c41A;
+        assertEq(
+            uint256(_verifyAaveV3Ltv0Position(walletWithLTV0Asset2)),
+            uint256(TriggerStatus.FALSE),
+            "trigger status should be FALSE"
+        );
+
+        address walletWithLinkInEmode = 0x3bb52B3101324197d765c7E27e79C6b0b5BE8BaB;
+        assertEq(
+            uint256(_verifyAaveV3Ltv0Position(walletWithLinkInEmode)),
+            uint256(TriggerStatus.TRUE),
+            "trigger status should be TRUE"
         );
     }
 }


### PR DESCRIPTION
### Summary

StrategyTriggerViewNoRevert will now flag position as not triggered if position has LTV0 asset used as collateral. Only added for Aave V3 leverage management strategies.

### Type of change

- [x] New Feature - A change that adds functionality.
- [ ] Bugfix - A change that resolves an issue.
- [ ] Tweak - A change that modifies existing features.
- [ ] Refactor - Code improvements without changing behavior.
- [ ] Performance - Optimizations for gas or execution efficiency.
- [ ] Documentation - Updates to docs, comments, or NatSpec.
- [ ] Tests - Adding or updating test coverage.
- [ ] Chore - Maintenance, dependencies, CI/CD, deployments or tooling updates.

### Details

_Provide any additional details if needed._

### References

_Link any existing PRs, such as SDK PRs related to this PR, or any additional references._

### Checks

#### For New Contracts

- [ ] Does the new contract have tests?
- [ ] Does the contract contain all the NatSpec needed (`@title`, `@notice`, `@param`, etc.)?
- [ ] Is the contract deployed and the address added to the JSON file?
- [ ] If the contract is registered, is the waitPeriod set correctly?
- [ ] Is the contract verified and added to the Tenderly dashboard?
- [ ] Is documentation written for the corresponding DFS action and added to GitBook?

#### For Modifications to Existing Contracts

- [x] If there were existing tests for the contract, are they adapted for the change and executed?
- [x] Is the contract redeployed and added to the JSON file?
- [ ] If the contract is registered, is the waitPeriod set correctly?
- [ ] Is the contract verified and added to the Tenderly dashboard?
- [ ] If some parameters were changed and a breaking change was introduced, is the documentation updated on GitBook?

#### For Strategies

- [ ] Are new tests added for the strategy?
- [ ] Is the strategy deployed and added to the JSON file?
