### PR TITLE
fix(contracts/utils/smartwalletutils.sol): fix: return wallet when Safe sole owner is a contract

### DIFF
--- a/contracts/utils/SmartWalletUtils.sol
+++ b/contracts/utils/SmartWalletUtils.sol
@@ -58,6 +58,7 @@ contract SmartWalletUtils is DSProxyFactoryHelper, DSAProxyFactoryHelper, SFProx
 
         // Otherwise, we assume we are in context of Safe
         address[] memory owners = ISafe(_wallet).getOwners();
-        return owners.length == 1 ? owners[0] : _wallet;
+        if (owners.length == 1 && owners[0].code.length == 0) return owners[0];
+        return _wallet;
     }
 }

--- a/test-sol/core/MultisigSafeAuth.t.sol
+++ b/test-sol/core/MultisigSafeAuth.t.sol
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: MIT
+pragma solidity =0.8.24;
+
+import "forge-std/Test.sol";
+import { MockSmartWalletUtils } from "../../contracts/mocks/MockSmartWalletUtils.sol";
+
+// Minimal mock Safe with a single owner
+contract MockSafeSingleOwner {
+    address[] internal _owners;
+
+    constructor(address owner_) {
+        _owners.push(owner_);
+    }
+
+    function getOwners() external view returns (address[] memory) {
+        return _owners;
+    }
+}
+
+// Minimal mock Safe with two owners
+contract MockSafeMultiOwner {
+    address[] internal _owners;
+
+    constructor(address owner1_, address owner2_) {
+        _owners.push(owner1_);
+        _owners.push(owner2_);
+    }
+
+    function getOwners() external view returns (address[] memory) {
+        return _owners;
+    }
+}
+
+// A dummy contract to simulate a contract-owner (e.g. outer multisig Safe)
+contract DummyContractOwner { }
+
+contract MultisigSafeAuthTest is Test {
+    MockSmartWalletUtils utils;
+
+    function setUp() public {
+        utils = new MockSmartWalletUtils();
+    }
+
+    // CASE 1 — 1/1 Safe with EOA owner
+    // Current behaviour: returns owners[0] (the EOA) — CORRECT
+    // Expected after fix: same, no change needed for this case
+    function test_fetchOwnerOrWallet_returnsEOA_forSingleEOAOwner() public {
+        address eoaOwner = address(0x1234);
+        MockSafeSingleOwner wallet = new MockSafeSingleOwner(eoaOwner);
+
+        address resolved = utils.fetchOwnerOrWallet(address(wallet));
+
+        assertEq(resolved, eoaOwner, "Should return EOA owner directly for a 1/1 EOA-owned Safe");
+    }
+
+    // CASE 2 — 1/1 Safe whose sole owner is a CONTRACT (nested Safe / outer multisig)
+    // Current behaviour: returns owners[0] which is a contract address — BUG
+    //   GUI treats it as EOA, tries personal_sign, stalls forever
+    // Expected after fix: returns wallet itself so EIP-1271 path is used
+    function test_fetchOwnerOrWallet_returnsWallet_forSingleContractOwner() public {
+        DummyContractOwner contractOwner = new DummyContractOwner();
+        MockSafeSingleOwner wallet = new MockSafeSingleOwner(address(contractOwner));
+
+        address resolved = utils.fetchOwnerOrWallet(address(wallet));
+
+        // THIS TEST SHOULD FAIL BEFORE THE FIX (returns contractOwner address)
+        // THIS TEST SHOULD PASS AFTER THE FIX  (returns wallet itself)
+        assertEq(
+            resolved,
+            address(wallet),
+            "Should return wallet itself when sole owner is a contract, not the contract owner"
+        );
+    }
+
+    // CASE 3 — Multisig Safe (2+ owners, at least one EOA)
+    // Current behaviour: returns wallet itself (owners.length != 1) — CORRECT at contract level
+    // but GUI still can't auth because it doesn't know which signer to prompt
+    // This test confirms the contract side behaves correctly already
+    function test_fetchOwnerOrWallet_returnsWallet_forMultipleOwners() public {
+        address owner1 = address(0x1111);
+        address owner2 = address(0x2222);
+        MockSafeMultiOwner wallet = new MockSafeMultiOwner(owner1, owner2);
+
+        address resolved = utils.fetchOwnerOrWallet(address(wallet));
+
+        assertEq(
+            resolved,
+            address(wallet),
+            "Should return wallet itself for a multisig Safe (multiple owners)"
+        );
+    }
+}


### PR DESCRIPTION
When a Safe's single owner is a contract (e.g. an outer multisig Safe),
_fetchOwnerOrWallet() was returning owners[0] — a contract address —
causing the GUI to attempt an EOA personal_sign on an unreachable address,
stalling Notify and Position Shifter indefinitely.

Fix: only return owners[0] if it is an EOA (code.length == 0).
Otherwise return the wallet itself so EIP-1271 validation is used.

Regression test: test-sol/core/MultisigSafeAuth.t.sol
Fixes #551 