### PR TITLE
test: remove AaveV4 from L2 tests

### DIFF
--- a/contracts/mocks/MockAuthorityAaveV4.sol
+++ b/contracts/mocks/MockAuthorityAaveV4.sol
@@ -3,7 +3,7 @@
 pragma solidity =0.8.24;
 
 contract MockAuthorityAaveV4 {
-    function canCall(address caller, address target, bytes4 selector) external view returns (bool) {
+    function canCall(address caller, address target, bytes4 selector) external pure returns (bool) {
         return true;
     }
 }

--- a/foundry.toml
+++ b/foundry.toml
@@ -17,19 +17,19 @@ fs_permissions = [{ access = 'read', path = './test-sol/config/' }]
 
 
 [profile.arbitrum]
-no_match_path = "test-sol/{actions,views,triggers,strategies}/*{eulerV2,etherFi,gho,liquityV2,pendle,renzo,sky,Sky,Spark,summerfi,Curve,Automation,aaveV3/umbrella,AaveView,aaveV4/aavev4/AaveV4View}*"
+no_match_path = "test-sol/{actions,views,triggers,strategies}/*{eulerV2,etherFi,gho,liquityV2,pendle,renzo,sky,Sky,Spark,summerfi,Curve,Automation,aaveV3/umbrella,AaveView,aaveV4,aavev4,AaveV4View,AaveV4}*"
 
 [profile.base]
-no_match_path = "test-sol/{actions,views,triggers,strategies}/*{eulerV2,etherFi,gho,liquityV2,pendle,renzo,sky,Sky,Spark,summerfi,Curve,Automation,aaveV3/umbrella,AaveView,aaveV4/aavev4/AaveV4View}*"
+no_match_path = "test-sol/{actions,views,triggers,strategies}/*{eulerV2,etherFi,gho,liquityV2,pendle,renzo,sky,Sky,Spark,summerfi,Curve,Automation,aaveV3/umbrella,AaveView,aaveV4.aavev4,AaveV4View,AaveV4}*"
 
 [profile.optimism]
-no_match_path = "test-sol/{actions,views,triggers,strategies}/*{eulerV2,etherFi,gho,liquityV2,pendle,renzo,sky,Sky,Spark,summerfi,Curve,Automation,aaveV3/umbrella,fluid,AaveView,aaveV4/aavev4/AaveV4View}*"
+no_match_path = "test-sol/{actions,views,triggers,strategies}/*{eulerV2,etherFi,gho,liquityV2,pendle,renzo,sky,Sky,Spark,summerfi,Curve,Automation,aaveV3/umbrella,fluid,AaveView,aaveV4,aavev4,AaveV4View,AaveV4}*"
 
 [profile.linea]
-match_path = "test-sol/{actions,core,views}/{aaveV3/AaveV3,AaveV3,DFSRegistry,RecipeExecutor,SafeModuleAuth,SmartWalletUtils,aaveV4/aavev4/AaveV4View}*"
+match_path = "test-sol/{actions,core,views}/{aaveV3/AaveV3,AaveV3,DFSRegistry,RecipeExecutor,SafeModuleAuth,SmartWalletUtils}*"
 
 [profile.plasma]
-match_path = "test-sol/{actions,core,views}/{aaveV3/AaveV3,AaveV3,DFSRegistry,RecipeExecutor,SafeModuleAuth,SmartWalletUtils,aaveV4/aavev4/AaveV4View}*"
+match_path = "test-sol/{actions,core,views}/{aaveV3/AaveV3,AaveV3,DFSRegistry,RecipeExecutor,SafeModuleAuth,SmartWalletUtils}*"
 
 
 # Formatting -> https://getfoundry.sh/config/reference/formatter/


### PR DESCRIPTION
### Summary

AaveV4 is not deployed on L2 at the moment, so remove it from `foundry.toml` setup

### Type of change

- [ ] New Feature - A change that adds functionality.
- [ ] Bugfix - A change that resolves an issue.
- [ ] Tweak - A change that modifies existing features.
- [ ] Refactor - Code improvements without changing behavior.
- [ ] Performance - Optimizations for gas or execution efficiency.
- [ ] Documentation - Updates to docs, comments, or NatSpec.
- [X] Tests - Adding or updating test coverage.
- [ ] Chore - Maintenance, dependencies, CI/CD, deployments or tooling updates.
