### PR TITLE
feat: add support for full repay on price

### DIFF
--- a/addresses/arbitrum.json
+++ b/addresses/arbitrum.json
@@ -1081,14 +1081,17 @@
     },
     {
         "name": "CompV3RatioCheck",
-        "address": "0xDB0b878b3A496E18F8a77dA47Ac76b07153f0899",
+        "address": "0x854E7099E98693Cb7c10870E0aB6EDCb9281E98C",
         "id": "0x2ce67bb9",
         "path": "contracts/actions/checkers/CompV3RatioCheck.sol",
-        "version": "1.0.1",
+        "version": "1.0.2",
         "inRegistry": true,
         "changeTime": "86400",
         "registryIds": [],
-        "history": ["0x9A481a33d27dE100de7Eb12d7c35028c1aCedDEa"]
+        "history": [
+            "0xDB0b878b3A496E18F8a77dA47Ac76b07153f0899",
+            "0x9A481a33d27dE100de7Eb12d7c35028c1aCedDEa"
+        ]
     },
     {
         "name": "CompV3SubProxyL2",
@@ -1747,14 +1750,14 @@
     },
     {
         "name": "MorphoBlueTargetRatioCheck",
-        "address": "0x83cc27951551188be7969e730A8e3AbB529Cc6c9",
+        "address": "0x68322C5844B97486a5c5479d7A702bEAb2e75857",
         "id": "0x49f12f40",
         "path": "contracts/actions/checkers/MorphoBlueTargetRatioCheck.sol",
-        "version": "1.0.0",
+        "version": "1.0.1",
         "inRegistry": true,
         "changeTime": "86400",
         "registryIds": [],
-        "history": []
+        "history": ["0x83cc27951551188be7969e730A8e3AbB529Cc6c9"]
     },
     {
         "name": "MorphoBluePriceTrigger",

--- a/addresses/arbitrum.json
+++ b/addresses/arbitrum.json
@@ -1344,14 +1344,15 @@
     },
     {
         "name": "AaveV3OpenRatioCheck",
-        "address": "0x2583Ce06479C26AB60AE554BE5dC57F7D4B3D9a1",
+        "address": "0x2aA8e70E1778e8DFBe9C74F300Ae719DB8d4aB4f",
         "id": "0x72b17abf",
         "path": "contracts/actions/checkers/AaveV3OpenRatioCheck.sol",
-        "version": "1.0.2",
+        "version": "1.0.3",
         "inRegistry": true,
         "changeTime": "86400",
         "registryIds": [],
         "history": [
+            "0x2583Ce06479C26AB60AE554BE5dC57F7D4B3D9a1",
             "0x99A36d26A2e1E6776057835C7B5E72A20c8cF5cb",
             "0x770e015485d4720398B08Ff226DB4ef29896b5B8"
         ]

--- a/addresses/base.json
+++ b/addresses/base.json
@@ -1273,14 +1273,15 @@
     },
     {
         "name": "AaveV3OpenRatioCheck",
-        "address": "0xD99D466087eb9b0A5a37C3dfdC2F2cFc1F59B8B2",
+        "address": "0xa9375b9919e7e43B069C33b7d9264299885EfB61",
         "id": "0x72b17abf",
         "path": "contracts/actions/checkers/AaveV3OpenRatioCheck.sol",
-        "version": "1.0.2",
+        "version": "1.0.3",
         "inRegistry": true,
         "changeTime": "86400",
         "registryIds": [],
         "history": [
+            "0xD99D466087eb9b0A5a37C3dfdC2F2cFc1F59B8B2",
             "0x9da74c3C4e2d79e04cfaD434fB679a97613fae7E",
             "0xFaC6148cf103BcAf3E90f6EB52373a231861Df18"
         ]

--- a/addresses/base.json
+++ b/addresses/base.json
@@ -1072,14 +1072,17 @@
     },
     {
         "name": "CompV3RatioCheck",
-        "address": "0x243022bBE8A6E52AFCbD4f21362a7B4124B9013C",
+        "address": "0xCa6e079A94e60f8a594492f2ceEa68930b5Bf6FE",
         "id": "0x2ce67bb9",
         "path": "contracts/actions/checkers/CompV3RatioCheck.sol",
-        "version": "1.0.1",
+        "version": "1.0.2",
         "inRegistry": true,
         "changeTime": "86400",
         "registryIds": [],
-        "history": ["0xC1ff2500790150c4a1c77B9e702e9984A252b60c"]
+        "history": [
+            "0x243022bBE8A6E52AFCbD4f21362a7B4124B9013C",
+            "0xC1ff2500790150c4a1c77B9e702e9984A252b60c"
+        ]
     },
     {
         "name": "MorphoBlueRatioTrigger",
@@ -1321,14 +1324,14 @@
     },
     {
         "name": "MorphoBlueTargetRatioCheck",
-        "address": "0x394fA7AeFe3ceCB3a79E0226c792134B0904dc4b",
+        "address": "0xbCe102593730e2b055D1C5E72be83Ffa2Eb17D3B",
         "id": "0x49f12f40",
         "path": "contracts/actions/checker/MorphoBlueTargetRatioCheck",
-        "version": "1.0.0",
+        "version": "1.0.1",
         "inRegistry": true,
         "changeTime": "86400",
         "registryIds": [],
-        "history": []
+        "history": ["0x394fA7AeFe3ceCB3a79E0226c792134B0904dc4b"]
     },
     {
         "name": "FluidVaultT1Open",

--- a/addresses/mainnet.json
+++ b/addresses/mainnet.json
@@ -3591,14 +3591,15 @@
     },
     {
         "name": "CompV3RatioCheck",
-        "address": "0xC98d94791216E6c5cf24FD3D2BBFdc577113331B",
+        "address": "0x314Bd8fFe51f6Ea7bAf978c61762F7eAaA1B5D34",
         "id": "0x2ce67bb9",
         "path": "contracts/actions/checkers/CompV3RatioCheck.sol",
-        "version": "1.0.2",
+        "version": "1.0.3",
         "inRegistry": true,
         "changeTime": "86400",
         "registryIds": [],
         "history": [
+            "0xC98d94791216E6c5cf24FD3D2BBFdc577113331B",
             "0x008E50774B26E92179fe25233E6ee7399c5A11F5",
             "0xEeb7e195d69479910d071Ac1dBC923A17d042960"
         ]
@@ -4015,14 +4016,14 @@
     },
     {
         "name": "MorphoBlueTargetRatioCheck",
-        "address": "0xC7D545749732dD4ce799ABd7Fc8e0900eEB2E564",
+        "address": "0x0b3C75c1D5EFA23d142B9177f81D61aC04AC79C5",
         "id": "0x49f12f40",
         "path": "contracts/actions/checker/MorphoBlueTargetRatioCheck",
-        "version": "1.0.0",
+        "version": "1.0.1",
         "inRegistry": true,
         "changeTime": "86400",
         "registryIds": [],
-        "history": []
+        "history": ["0xC7D545749732dD4ce799ABd7Fc8e0900eEB2E564"]
     },
     {
         "name": "LiquityV2CloseLegacy",
@@ -4820,14 +4821,14 @@
     },
     {
         "name": "SparkTargetRatioCheck",
-        "address": "0x4E5044F622C0FcAb587106847F4889d3AB065c79",
+        "address": "0xb43405A165b6827c665dAE8Da5b81773D9c09F94",
         "id": "0x66d60c1e",
         "path": "contracts/actions/checkers/SparkTargetRatioCheck.sol",
-        "version": "1.0.0",
+        "version": "1.0.1",
         "inRegistry": true,
         "changeTime": "86400",
         "registryIds": [],
-        "history": []
+        "history": ["0x4E5044F622C0FcAb587106847F4889d3AB065c79"]
     },
     {
         "name": "SFProxyEntryPoint",
@@ -4941,14 +4942,14 @@
     },
     {
         "name": "AaveV4RatioCheck",
-        "address": "0x63711684b09cD80b4E696E5D5Af397d38a511Deb",
+        "address": "0xC45f793838FD019507b6e6b0651b1CcefDC09d8a",
         "id": "0x707ad6fd",
         "path": "contracts/actions/checkers/AaveV4RatioCheck.sol",
-        "version": "1.0.0",
+        "version": "1.0.1",
         "inRegistry": true,
         "changeTime": "86400",
         "registryIds": [],
-        "history": []
+        "history": ["0x63711684b09cD80b4E696E5D5Af397d38a511Deb"]
     },
     {
         "name": "AaveV4RatioTrigger",

--- a/addresses/mainnet.json
+++ b/addresses/mainnet.json
@@ -3780,14 +3780,15 @@
     },
     {
         "name": "AaveV3OpenRatioCheck",
-        "address": "0x4100c55Ee98aB045a8cF31Ae84f878B0A3b4F290",
+        "address": "0x4619925Fb0054219d74ECf7108B3c2851a8a47aE",
         "id": "0x72b17abf",
         "path": "contracts/actions/checkers/AaveV3OpenRatioCheck.sol",
-        "version": "1.0.2",
+        "version": "1.0.3",
         "inRegistry": true,
         "changeTime": "86400",
         "registryIds": [],
         "history": [
+            "0x4100c55Ee98aB045a8cF31Ae84f878B0A3b4F290",
             "0x7449c0830B10cbd1BaD1Aa4427Ccb41Fd5C75be5",
             "0xaFD184d6E048c3C8D18356ef4E9adA024E6fb31c"
         ]

--- a/addresses/optimism.json
+++ b/addresses/optimism.json
@@ -1170,14 +1170,15 @@
     },
     {
         "name": "AaveV3OpenRatioCheck",
-        "address": "0x64bfC6d69a43E999728C63EBBA188D2c198ee66B",
+        "address": "0x8803e8529C34669637BD1e1b3Eefc91eB1488F80",
         "id": "0x72b17abf",
         "path": "contracts/actions/checkers/AaveV3OpenRatioCheck.sol",
-        "version": "1.0.2",
+        "version": "1.0.3",
         "inRegistry": true,
         "changeTime": "86400",
         "registryIds": [],
         "history": [
+            "0x64bfC6d69a43E999728C63EBBA188D2c198ee66B",
             "0xAF5D3604B1bE08fadD239b2A7353F01786cE4b0e",
             "0xA41baFAE6832D6D059eEcac0eBB46c4D8c16c248"
         ]

--- a/contracts/actions/aaveV3/helpers/AaveV3RatioHelper.sol
+++ b/contracts/actions/aaveV3/helpers/AaveV3RatioHelper.sol
@@ -189,4 +189,9 @@ contract AaveV3RatioHelper is DSMath, MainnetAaveV3Addresses {
             return (_bitmap >> _reserveIndex) & 1 != 0;
         }
     }
+
+    /// @dev Helper function to check if ratio is 0, used for better readability.
+    function isRatioZero(uint256 _ratio) internal pure returns (bool) {
+        return _ratio == 0;
+    }
 }

--- a/contracts/actions/aavev4/helpers/AaveV4RatioHelper.sol
+++ b/contracts/actions/aavev4/helpers/AaveV4RatioHelper.sol
@@ -18,4 +18,12 @@ contract AaveV4RatioHelper {
     function getRatio(address _spoke, address _user) public view returns (uint256) {
         return ISpoke(_spoke).getUserAccountData(_user).healthFactor;
     }
+
+    function _isRatioZero(uint256 _ratio) internal pure returns (bool) {
+        return _ratio == 0;
+    }
+
+    function _isRatioUintMax(uint256 _ratio) internal pure returns (bool) {
+        return _ratio == type(uint256).max;
+    }
 }

--- a/contracts/actions/checkers/AaveV3OpenRatioCheck.sol
+++ b/contracts/actions/checkers/AaveV3OpenRatioCheck.sol
@@ -50,10 +50,19 @@ contract AaveV3OpenRatioCheck is ActionBase, AaveV3RatioHelper {
 
         /// @notice If `targetRatio` is 999% or more then skip `RATIO_OFFSET` check because it is very hard to be precise under 5%.
         if (targetRatio < RATIO_LIMIT) {
-            if (
-                currRatio > (targetRatio + RATIO_OFFSET) || currRatio < (targetRatio - RATIO_OFFSET)
-            ) {
-                revert BadAfterRatio(currRatio, targetRatio);
+            /// @notice If user is subscribed on full repay, currRatio must be exactly 0
+            if (isRatioZero(targetRatio)) {
+                if (!isRatioZero(currRatio)) {
+                    revert BadAfterRatio(currRatio, targetRatio);
+                }
+            } else {
+                /// @notice Normal repay with target ratio, we accept 5% offset
+                if (
+                    currRatio > (targetRatio + RATIO_OFFSET)
+                        || currRatio < (targetRatio - RATIO_OFFSET)
+                ) {
+                    revert BadAfterRatio(currRatio, targetRatio);
+                }
             }
         }
 

--- a/contracts/actions/checkers/AaveV3OpenRatioCheck.sol
+++ b/contracts/actions/checkers/AaveV3OpenRatioCheck.sol
@@ -56,7 +56,7 @@ contract AaveV3OpenRatioCheck is ActionBase, AaveV3RatioHelper {
                     revert BadAfterRatio(currRatio, targetRatio);
                 }
             } else {
-                /// @notice Normal repay with target ratio, we accept 5% offset
+                /// @notice Normal repay/boost on price with target ratio, we accept 5% offset
                 if (
                     currRatio > (targetRatio + RATIO_OFFSET)
                         || currRatio < (targetRatio - RATIO_OFFSET)

--- a/contracts/actions/checkers/AaveV4RatioCheck.sol
+++ b/contracts/actions/checkers/AaveV4RatioCheck.sol
@@ -54,9 +54,16 @@ contract AaveV4RatioCheck is ActionBase, AaveV4RatioHelper {
         uint256 start = uint256(tempStorage.getBytes32(AAVE_V4_RATIO_KEY));
 
         if (params.ratioState == RatioState.IN_REPAY) {
-            // Repay: Ratio must increase but not overshoot 'target + offset' to avoid boost after.
-            if (current <= start || current > params.targetRatio + RATIO_OFFSET) {
-                revert BadAfterRatio(start, current);
+            /// @notice If user is subscribed on full repay, target ratio will be 0 for compatibility with other protocols. But in aave v4 protocol real ratio when user has no debt will be max uint256, hence check that current is max uint256 in that case.
+            if (_isRatioZero(params.targetRatio)) {
+                if (!_isRatioUintMax(current)) {
+                    revert BadAfterRatio(start, current);
+                }
+            } else {
+                if (current <= start || current > params.targetRatio + RATIO_OFFSET) {
+                    // Repay: Ratio must increase but not overshoot 'target + offset' to avoid boost after.
+                    revert BadAfterRatio(start, current);
+                }
             }
         } else {
             // Boost: Ratio must decrease but not undershoot 'target - offset' to avoid repay after.

--- a/contracts/actions/checkers/AaveV4RatioCheck.sol
+++ b/contracts/actions/checkers/AaveV4RatioCheck.sol
@@ -54,7 +54,8 @@ contract AaveV4RatioCheck is ActionBase, AaveV4RatioHelper {
         uint256 start = uint256(tempStorage.getBytes32(AAVE_V4_RATIO_KEY));
 
         if (params.ratioState == RatioState.IN_REPAY) {
-            /// @notice If user is subscribed on full repay, target ratio will be 0 for compatibility with other protocols. But in aave v4 protocol real ratio when user has no debt will be max uint256, hence check that current is max uint256 in that case.
+            // Full-repay subscriptions use targetRatio = 0 for cross-protocol compatibility.
+            // In Aave V4, a debt-free position has ratio = type(uint256).max, so verify currentRatio is max in that case.
             if (_isRatioZero(params.targetRatio)) {
                 if (!_isRatioUintMax(current)) {
                     revert BadAfterRatio(start, current);

--- a/contracts/actions/checkers/CompV3RatioCheck.sol
+++ b/contracts/actions/checkers/CompV3RatioCheck.sol
@@ -77,17 +77,9 @@ contract CompV3RatioCheck is ActionBase, CompV3RatioHelper {
                     revert BadAfterRatio(startRatio, currRatio);
                 }
             }
-        }
-
-        // if we are doing boost
-        if (RatioState(ratioState) == RatioState.IN_BOOST) {
-            // if boost ratio should be less
-            if (currRatio >= startRatio) {
-                revert BadAfterRatio(startRatio, currRatio);
-            }
-
-            // can't boost too much under targetRatio so we don't trigger repay after
-            if (currRatio < (targetRatio - RATIO_OFFSET)) {
+        } else {
+            // Boost: Ratio must decrease but not undershoot 'target - offset' to avoid repay after.
+            if (currRatio >= startRatio || currRatio < targetRatio - RATIO_OFFSET) {
                 revert BadAfterRatio(startRatio, currRatio);
             }
         }

--- a/contracts/actions/checkers/CompV3RatioCheck.sol
+++ b/contracts/actions/checkers/CompV3RatioCheck.sol
@@ -66,14 +66,16 @@ contract CompV3RatioCheck is ActionBase, CompV3RatioHelper {
 
         // if we are doing repay
         if (RatioState(ratioState) == RatioState.IN_REPAY) {
-            // if repay ratio should be better off
-            if (currRatio <= startRatio) {
-                revert BadAfterRatio(startRatio, currRatio);
-            }
-
-            // can't repay too much over targetRatio so we don't trigger boost after
-            if (currRatio > (targetRatio + RATIO_OFFSET)) {
-                revert BadAfterRatio(startRatio, currRatio);
+            /// @notice If user is subscribed on full repay, currRatio must be exactly 0
+            if (_isRatioZero(targetRatio)) {
+                if (!_isRatioZero(currRatio)) {
+                    revert BadAfterRatio(startRatio, currRatio);
+                }
+            } else {
+                if (currRatio <= startRatio || currRatio > targetRatio + RATIO_OFFSET) {
+                    // Repay: Ratio must increase but not overshoot 'target + offset' to avoid boost after.
+                    revert BadAfterRatio(startRatio, currRatio);
+                }
             }
         }
 

--- a/contracts/actions/checkers/MorphoBlueTargetRatioCheck.sol
+++ b/contracts/actions/checkers/MorphoBlueTargetRatioCheck.sol
@@ -11,6 +11,8 @@ import { ActionBase } from "../ActionBase.sol";
 contract MorphoBlueTargetRatioCheck is ActionBase, MorphoBlueHelper {
     /// @notice 5% offset acceptable
     uint256 internal constant RATIO_OFFSET = 5e16;
+    /// @notice We are checking for 5% RATIO_OFFSET only when the target ratio is < 999%
+    uint256 internal constant RATIO_LIMIT = 999e16;
 
     error BadAfterRatio(uint256 currentRatio, uint256 targetRatio);
 
@@ -51,11 +53,22 @@ contract MorphoBlueTargetRatioCheck is ActionBase, MorphoBlueHelper {
 
         uint256 currRatio = getRatioUsingParams(inputData.marketParams, inputData.user);
 
-        if (
-            currRatio > (inputData.targetRatio + RATIO_OFFSET)
-                || currRatio < (inputData.targetRatio - RATIO_OFFSET)
-        ) {
-            revert BadAfterRatio(currRatio, inputData.targetRatio);
+        /// @notice If `targetRatio` is 999% or more then skip `RATIO_OFFSET` check because it is very hard to be precise under 5%.
+        if (inputData.targetRatio < RATIO_LIMIT) {
+            /// @notice If user is subscribed on full repay, currRatio must be exactly 0
+            if (_isRatioZero(inputData.targetRatio)) {
+                if (!_isRatioZero(currRatio)) {
+                    revert BadAfterRatio(currRatio, inputData.targetRatio);
+                }
+            } else {
+                /// @notice Normal repay/boost on price with target ratio, we accept 5% offset
+                if (
+                    currRatio > (inputData.targetRatio + RATIO_OFFSET)
+                        || currRatio < (inputData.targetRatio - RATIO_OFFSET)
+                ) {
+                    revert BadAfterRatio(currRatio, inputData.targetRatio);
+                }
+            }
         }
 
         emit ActionEvent("MorphoBlueTargetRatioCheck", abi.encode(currRatio));

--- a/contracts/actions/checkers/SparkTargetRatioCheck.sol
+++ b/contracts/actions/checkers/SparkTargetRatioCheck.sol
@@ -40,10 +40,19 @@ contract SparkTargetRatioCheck is ActionBase, SparkRatioHelper {
 
         /// @notice If `targetRatio` is 999% or more then skip `RATIO_OFFSET` check because it is very hard to be precise under 5%.
         if (targetRatio < RATIO_LIMIT) {
-            if (
-                currRatio > (targetRatio + RATIO_OFFSET) || currRatio < (targetRatio - RATIO_OFFSET)
-            ) {
-                revert BadAfterRatio(currRatio, targetRatio);
+            /// @notice If user is subscribed on full repay, currRatio must be exactly 0
+            if (_isRatioZero(targetRatio)) {
+                if (!_isRatioZero(currRatio)) {
+                    revert BadAfterRatio(currRatio, targetRatio);
+                }
+            } else {
+                /// @notice Normal repay/boost on price with target ratio, we accept 5% offset
+                if (
+                    currRatio > (targetRatio + RATIO_OFFSET)
+                        || currRatio < (targetRatio - RATIO_OFFSET)
+                ) {
+                    revert BadAfterRatio(currRatio, targetRatio);
+                }
             }
         }
 

--- a/contracts/actions/compoundV3/helpers/CompV3RatioHelper.sol
+++ b/contracts/actions/compoundV3/helpers/CompV3RatioHelper.sol
@@ -47,4 +47,8 @@ contract CompV3RatioHelper is DSMath, MainnetCompV3Addresses {
     function isInAsset(uint16 assetsIn, uint8 assetOffset) internal pure returns (bool) {
         return (assetsIn & (uint16(1) << assetOffset) != 0);
     }
+
+    function _isRatioZero(uint256 _ratio) internal pure returns (bool) {
+        return _ratio == 0;
+    }
 }

--- a/contracts/actions/morpho-blue/helpers/MorphoBlueHelper.sol
+++ b/contracts/actions/morpho-blue/helpers/MorphoBlueHelper.sol
@@ -78,4 +78,8 @@ contract MorphoBlueHelper is MainnetMorphoBlueAddresses {
         if (debt == 0) return 0;
         ratio = collateral * oraclePrice / debt / 1e18;
     }
+
+    function _isRatioZero(uint256 _ratio) internal pure returns (bool) {
+        return _ratio == 0;
+    }
 }

--- a/contracts/actions/spark/helpers/SparkRatioHelper.sol
+++ b/contracts/actions/spark/helpers/SparkRatioHelper.sol
@@ -24,4 +24,8 @@ contract SparkRatioHelper is DSMath, MainnetSparkAddresses {
         // For each asset the account is in
         return getSafetyRatio(_market, _user);
     }
+
+    function _isRatioZero(uint256 _ratio) internal pure returns (bool) {
+        return _ratio == 0;
+    }
 }

--- a/scripts/utils/deployer.js
+++ b/scripts/utils/deployer.js
@@ -2,9 +2,49 @@ require('dotenv-safe').config();
 
 const hre = require('hardhat');
 const ethers = require('ethers');
+const axios = require('axios');
 const { write } = require('./writer');
 
 const DEPLOYMENT_GAS_LIMIT = 30_000_000;
+
+// Verify a deployed contract on the Tenderly VNet via its Etherscan-compatible `<rpc>/verify`.
+const verifyOnTenderlyFork = async (contractName, contract, args) => {
+    try {
+        const fqn = (await hre.artifacts.getAllFullyQualifiedNames()).find(
+            (n) => n === contractName || n.endsWith(`:${contractName}`),
+        );
+        const buildInfo = await hre.artifacts.getBuildInfo(fqn);
+        const [sourceName, shortName] = fqn.split(':');
+        const usedSources = JSON.parse(
+            buildInfo.output.contracts[sourceName][shortName].metadata,
+        ).sources;
+
+        const params = new URLSearchParams({
+            module: 'contract',
+            action: 'verifysourcecode',
+            apikey: process.env.TENDERLY_ACCESS_KEY || 'tenderly',
+            codeformat: 'solidity-standard-json-input',
+            sourceCode: JSON.stringify({
+                ...buildInfo.input,
+                sources: Object.fromEntries(
+                    Object.keys(usedSources).map((s) => [s, buildInfo.input.sources[s]]),
+                ),
+            }),
+            contractname: fqn,
+            compilerversion: `v${buildInfo.solcLongVersion}`,
+            contractaddress: contract.address,
+            constructorArguements: contract.interface.encodeDeploy(args).slice(2),
+        });
+
+        const res = await axios.post(`${hre.network.config.url}/verify`, params.toString(), {
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+            timeout: 180_000,
+        });
+        console.log(`[verify] ${contractName}:`, JSON.stringify(res.data));
+    } catch (e) {
+        console.log(`[verify] ${contractName} failed:`, e.response?.data || e.message);
+    }
+};
 
 const getGasPrice = async (exGasPrice) => {
     let defaultGasPrice = 1000000000000;
@@ -58,6 +98,11 @@ const deploy = async (contractName, signer, action, gasPrice, nonce, ...args) =>
         console.log(`Mainnet link: https://etherscan.io/address/${contract.address}`);
 
         await write(contractName, hre.network.name, contract.address, ...args);
+
+        if (hre.network.config.type === 'tenderly') {
+            await verifyOnTenderlyFork(contractName, contract, args);
+        }
+
         console.log('-------------------------------------------------------------');
         return contract;
     } catch (e) {

--- a/test-sol/actions/checkers/AaveV3OpenRatioCheck.t.sol
+++ b/test-sol/actions/checkers/AaveV3OpenRatioCheck.t.sol
@@ -8,6 +8,7 @@ import { AaveV3RatioHelper } from "../../../contracts/actions/aaveV3/helpers/Aav
 import { ActionBase } from "../../../contracts/actions/ActionBase.sol";
 import { DataTypes } from "../../../contracts/interfaces/protocols/aaveV3/DataTypes.sol";
 
+import { BaseTest } from "../../utils/BaseTest.sol";
 import { SmartWallet } from "../../utils/SmartWallet.sol";
 import { AaveV3PositionCreator } from "../../utils/positions/AaveV3PositionCreator.sol";
 import { AaveV3Encode } from "../../utils/encode/AaveV3Encode.sol";
@@ -254,5 +255,69 @@ contract TestAaveV3OpenRatioCheck is AaveV3RatioHelper, AaveV3PositionCreator {
         return abi.encodeWithSelector(
             ActionBase.executeAction.selector, paramsCalldata, subData, pm, returnValues
         );
+    }
+}
+
+/// @title Read-only checks for AaveV3OpenRatioCheck against real LTV-zero positions.
+/// @notice Pinned to mainnet block 24_929_244 (see test-sol/config/config.json). These positions
+///         hold LTV-zero collateral. We verify getRatio does NOT report 0 for them, so the full
+///         repay path (targetRatio == 0) never mistakes an indebted position for a fully repaid one.
+contract TestAaveV3OpenRatioCheckLtvZero is BaseTest, AaveV3RatioHelper {
+    /*//////////////////////////////////////////////////////////////////////////
+                               CONTRACT UNDER TEST
+    //////////////////////////////////////////////////////////////////////////*/
+    AaveV3OpenRatioCheck cut;
+
+    function setUp() public override {
+        forkFromEnv("ETH-ltv0");
+
+        if (!isMainnetSelected()) {
+            vm.skip(true, "Test only supported on Mainnet");
+        }
+
+        cut = new AaveV3OpenRatioCheck();
+    }
+
+    /// @dev Real LTV-zero positions present at the pinned block.
+    function _positions() internal pure returns (address[4] memory) {
+        return [
+            0x34780C209D5C575cc1C1cEB57aF95D4d2a69ddCF,
+            0x5dc2da72254FC303680A7d644198EDFdbdF07883,
+            0x28a55C4b4f9615FDE3CDAdDf6cc01FcF2E38A6b0,
+            0xe40d278afD00E6187Db21ff8C96D572359Ef03bf
+        ];
+    }
+
+    /// @notice None of these LTV-zero positions should report a zero ratio.
+    function test_ltv_zero_positions_have_nonzero_ratio() public view {
+        address[4] memory positions = _positions();
+        for (uint256 i = 0; i < positions.length; ++i) {
+            uint256 currRatio = cut.getRatio(DEFAULT_AAVE_MARKET, positions[i]);
+            assertGt(currRatio, 0, "LTV-zero position reported zero ratio");
+        }
+    }
+
+    /// @notice With targetRatio == 0 the check must revert for these still-indebted positions,
+    ///         proving the full repay check does not wrongly accept them as fully repaid.
+    function test_full_repay_check_reverts_for_ltv_zero_positions() public {
+        address[4] memory positions = _positions();
+        for (uint256 i = 0; i < positions.length; ++i) {
+            uint256 currRatio = cut.getRatio(DEFAULT_AAVE_MARKET, positions[i]);
+
+            bytes memory paramsCalldata = abi.encode(
+                AaveV3OpenRatioCheck.Params({
+                    targetRatio: 0, market: DEFAULT_AAVE_MARKET, user: positions[i]
+                })
+            );
+            // length 3 so the `user` param is honored by the action
+            uint8[] memory pm = new uint8[](3);
+
+            vm.expectRevert(
+                abi.encodeWithSelector(
+                    AaveV3OpenRatioCheck.BadAfterRatio.selector, currRatio, uint256(0)
+                )
+            );
+            cut.executeAction(paramsCalldata, new bytes32[](0), pm, new bytes32[](0));
+        }
     }
 }

--- a/test-sol/actions/checkers/AaveV3OpenRatioCheck.t.sol
+++ b/test-sol/actions/checkers/AaveV3OpenRatioCheck.t.sol
@@ -1,0 +1,258 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity =0.8.24;
+
+import { AaveV3OpenRatioCheck } from "../../../contracts/actions/checkers/AaveV3OpenRatioCheck.sol";
+import { AaveV3Payback } from "../../../contracts/actions/aaveV3/AaveV3Payback.sol";
+import { AaveV3RatioHelper } from "../../../contracts/actions/aaveV3/helpers/AaveV3RatioHelper.sol";
+import { ActionBase } from "../../../contracts/actions/ActionBase.sol";
+import { DataTypes } from "../../../contracts/interfaces/protocols/aaveV3/DataTypes.sol";
+
+import { SmartWallet } from "../../utils/SmartWallet.sol";
+import { AaveV3PositionCreator } from "../../utils/positions/AaveV3PositionCreator.sol";
+import { AaveV3Encode } from "../../utils/encode/AaveV3Encode.sol";
+import { console2 } from "forge-std/console2.sol";
+
+/// @title Unit tests for AaveV3OpenRatioCheck.
+/// @notice Focused on the full repay support, where `targetRatio == 0` means the strategy
+///         must leave the position with no debt (ratio == 0) and keep the extra collateral.
+contract TestAaveV3OpenRatioCheck is AaveV3RatioHelper, AaveV3PositionCreator {
+    /*//////////////////////////////////////////////////////////////////////////
+                               CONTRACT UNDER TEST
+    //////////////////////////////////////////////////////////////////////////*/
+    AaveV3OpenRatioCheck cut;
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                    VARIABLES
+    //////////////////////////////////////////////////////////////////////////*/
+    AaveV3Payback paybackAction;
+    SmartWallet wallet;
+    address walletAddr;
+    address sender;
+
+    /// @dev Mirrors AaveV3OpenRatioCheck.RATIO_OFFSET (5% acceptable offset).
+    uint256 internal constant RATIO_OFFSET = 5e16;
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                  SETUP FUNCTION
+    //////////////////////////////////////////////////////////////////////////*/
+    function setUp() public override {
+        forkFromEnv("");
+        initTestPairs("AaveV3");
+
+        wallet = new SmartWallet(bob);
+        sender = wallet.owner();
+        walletAddr = wallet.walletAddr();
+
+        AaveV3PositionCreator.setUp();
+        cut = new AaveV3OpenRatioCheck();
+        paybackAction = new AaveV3Payback();
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                       FULL REPAY TESTS (targetRatio == 0)
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @notice Full repay leaves the position with no debt, so the safety ratio is 0.
+    ///         With `targetRatio == 0` the check must pass.
+    function test_should_pass_full_repay_when_no_debt_left() public {
+        for (uint256 i = 0; i < testPairs.length; ++i) {
+            uint256 snapshotId = vm.snapshotState();
+
+            if (_createPositionOrSkip(i) && _fullPayback(testPairs[i].borrowAsset)) {
+                uint256 currRatio = cut.getRatio(DEFAULT_AAVE_MARKET, walletAddr);
+                assertEq(currRatio, 0, "Ratio should be 0 after full repay");
+
+                // Should not revert: target is 0 and there is no debt left.
+                wallet.execute(address(cut), _checkCalldata(0), 0);
+            }
+
+            vm.revertToState(snapshotId);
+        }
+    }
+
+    /// @notice With `targetRatio == 0` but debt still present, the check must revert,
+    ///         since a full repay strategy is only allowed to finish with no debt.
+    function test_should_revert_full_repay_when_debt_left() public {
+        for (uint256 i = 0; i < testPairs.length; ++i) {
+            uint256 snapshotId = vm.snapshotState();
+
+            if (_createPositionOrSkip(i)) {
+                uint256 currRatio = cut.getRatio(DEFAULT_AAVE_MARKET, walletAddr);
+                assertGt(currRatio, 0, "Position should still have debt");
+
+                (bytes memory paramsCalldata, uint8[] memory pm) = _checkParams(0);
+                vm.expectRevert(
+                    abi.encodeWithSelector(
+                        AaveV3OpenRatioCheck.BadAfterRatio.selector, currRatio, uint256(0)
+                    )
+                );
+                cut.executeAction(paramsCalldata, subData, pm, returnValues);
+            }
+
+            vm.revertToState(snapshotId);
+        }
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                       NORMAL TARGET TESTS (regression)
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @notice Non-zero target within the 5% offset still passes (the non full repay branch).
+    function test_should_pass_normal_target_within_offset() public {
+        for (uint256 i = 0; i < testPairs.length; ++i) {
+            uint256 snapshotId = vm.snapshotState();
+
+            if (_createPositionOrSkip(i)) {
+                uint256 currRatio = cut.getRatio(DEFAULT_AAVE_MARKET, walletAddr);
+                // target == currRatio => trivially within the accepted offset.
+                wallet.execute(address(cut), _checkCalldata(currRatio), 0);
+            }
+
+            vm.revertToState(snapshotId);
+        }
+    }
+
+    /// @notice Non-zero target below the 5% offset must revert (the non full repay branch).
+    function test_should_revert_normal_target_below_offset() public {
+        for (uint256 i = 0; i < testPairs.length; ++i) {
+            uint256 snapshotId = vm.snapshotState();
+
+            if (_createPositionOrSkip(i)) {
+                uint256 currRatio = cut.getRatio(DEFAULT_AAVE_MARKET, walletAddr);
+                // currRatio > targetRatio + RATIO_OFFSET => revert.
+                uint256 targetRatio = currRatio - 2 * RATIO_OFFSET;
+
+                (bytes memory paramsCalldata, uint8[] memory pm) = _checkParams(targetRatio);
+                vm.expectRevert(
+                    abi.encodeWithSelector(
+                        AaveV3OpenRatioCheck.BadAfterRatio.selector, currRatio, targetRatio
+                    )
+                );
+                cut.executeAction(paramsCalldata, subData, pm, returnValues);
+            }
+
+            vm.revertToState(snapshotId);
+        }
+    }
+
+    /// @notice Non-zero target above the 5% offset must revert (the non full repay branch).
+    function test_should_revert_normal_target_above_offset() public {
+        for (uint256 i = 0; i < testPairs.length; ++i) {
+            uint256 snapshotId = vm.snapshotState();
+
+            if (_createPositionOrSkip(i)) {
+                uint256 currRatio = cut.getRatio(DEFAULT_AAVE_MARKET, walletAddr);
+                // currRatio < targetRatio - RATIO_OFFSET => revert.
+                uint256 targetRatio = currRatio + 2 * RATIO_OFFSET;
+
+                (bytes memory paramsCalldata, uint8[] memory pm) = _checkParams(targetRatio);
+                vm.expectRevert(
+                    abi.encodeWithSelector(
+                        AaveV3OpenRatioCheck.BadAfterRatio.selector, currRatio, targetRatio
+                    )
+                );
+                cut.executeAction(paramsCalldata, subData, pm, returnValues);
+            }
+
+            vm.revertToState(snapshotId);
+        }
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                     HELPERS
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @dev Opens a 100k coll / 40k debt position for the given test pair.
+    ///      Returns false (and logs) when the pair can't be used on the selected network.
+    function _createPositionOrSkip(uint256 _i) internal returns (bool) {
+        PositionParams memory positionParams = PositionParams({
+            collAddr: testPairs[_i].supplyAsset,
+            collAmount: amountInUSDPrice(testPairs[_i].supplyAsset, 100_000),
+            debtAddr: testPairs[_i].borrowAsset,
+            debtAmount: amountInUSDPrice(testPairs[_i].borrowAsset, 40_000)
+        });
+
+        if (!isValidSupply(DEFAULT_AAVE_MARKET, positionParams.collAddr, positionParams.collAmount))
+        {
+            console2.log("[AaveV3OpenRatioCheck] Can't supply asset. Skipping pair...");
+            return false;
+        }
+        if (!isValidBorrow(DEFAULT_AAVE_MARKET, positionParams.debtAddr, positionParams.debtAmount))
+        {
+            console2.log("[AaveV3OpenRatioCheck] Can't borrow asset. Skipping pair...");
+            return false;
+        }
+
+        createAaveV3Position(positionParams, wallet);
+        return true;
+    }
+
+    /// @dev Fully pays back the wallet's variable debt for `_debtAddr`, leaving the collateral.
+    ///      Returns false (and logs) when the asset can't be repaid on the selected network.
+    function _fullPayback(address _debtAddr) internal returns (bool) {
+        if (!isValidRepay(DEFAULT_AAVE_MARKET, _debtAddr)) {
+            console2.log("[AaveV3OpenRatioCheck] Can't repay asset. Skipping pair...");
+            return false;
+        }
+
+        DataTypes.ReserveData memory reserveData = pool.getReserveData(_debtAddr);
+        uint16 debtAssetId = reserveData.id;
+        address debtVariableTokenAddr = reserveData.variableDebtTokenAddress;
+
+        uint256 walletVariableDebt = balanceOf(debtVariableTokenAddr, walletAddr);
+
+        // Give double the debt to cover any accrued interest, then repay with max uint.
+        give(_debtAddr, sender, walletVariableDebt * 2);
+        approveAsSender(sender, _debtAddr, walletAddr, walletVariableDebt * 2);
+
+        bytes memory paramsCalldata = AaveV3Encode.payback(
+            type(uint256).max,
+            sender,
+            uint8(DataTypes.InterestRateMode.VARIABLE),
+            debtAssetId,
+            true,
+            false,
+            address(0),
+            address(0)
+        );
+        bytes memory _calldata = abi.encodeWithSelector(
+            AaveV3Payback.executeAction.selector,
+            paramsCalldata,
+            subData,
+            paramMapping,
+            returnValues
+        );
+        wallet.execute(address(paybackAction), _calldata, 0);
+
+        // Verify the full repay end state matches the feature intent:
+        // no debt left, while the collateral stays in the position.
+        (uint256 totalCollateralBase, uint256 totalDebtBase,,,,) =
+            pool.getUserAccountData(walletAddr);
+        assertEq(totalDebtBase, 0, "Debt not fully repaid");
+        assertGt(totalCollateralBase, 0, "Collateral should remain after full repay");
+        return true;
+    }
+
+    /// @dev Builds the check params and a 3-length paramMapping so the `user` param is honored
+    ///      (see AaveV3OpenRatioCheck: the `user` field is only read when paramMapping.length == 3).
+    function _checkParams(uint256 _targetRatio)
+        internal
+        view
+        returns (bytes memory paramsCalldata, uint8[] memory pm)
+    {
+        paramsCalldata = abi.encode(
+            AaveV3OpenRatioCheck.Params({
+                targetRatio: _targetRatio, market: DEFAULT_AAVE_MARKET, user: walletAddr
+            })
+        );
+        pm = new uint8[](3);
+    }
+
+    function _checkCalldata(uint256 _targetRatio) internal view returns (bytes memory) {
+        (bytes memory paramsCalldata, uint8[] memory pm) = _checkParams(_targetRatio);
+        return abi.encodeWithSelector(
+            ActionBase.executeAction.selector, paramsCalldata, subData, pm, returnValues
+        );
+    }
+}

--- a/test-sol/actions/checkers/AaveV4RatioCheck.t.sol
+++ b/test-sol/actions/checkers/AaveV4RatioCheck.t.sol
@@ -2,10 +2,12 @@
 
 pragma solidity =0.8.24;
 
+import { ISpoke } from "../../../contracts/interfaces/protocols/aaveV4/ISpoke.sol";
 import {
     TransientStorageCancun
 } from "../../../contracts/utils/transient/TransientStorageCancun.sol";
 import { Addresses } from "test-sol/utils/helpers/MainnetAddresses.sol";
+import { AaveV4Payback } from "../../../contracts/actions/aaveV4/AaveV4Payback.sol";
 import { AaveV4RatioCheck } from "../../../contracts/actions/checkers/AaveV4RatioCheck.sol";
 import { SmartWallet } from "test-sol/utils/SmartWallet.sol";
 import { AaveV4TestBase } from "../aaveV4/AaveV4TestBase.t.sol";
@@ -17,6 +19,7 @@ contract TestAaveV4RatioCheck is AaveV4TestBase {
                                CONTRACT UNDER TEST
     //////////////////////////////////////////////////////////////////////////*/
     AaveV4RatioCheck cut;
+    AaveV4Payback paybackAction;
     /*//////////////////////////////////////////////////////////////////////////
                                     VARIABLES
     //////////////////////////////////////////////////////////////////////////*/
@@ -44,6 +47,72 @@ contract TestAaveV4RatioCheck is AaveV4TestBase {
         walletAddr = wallet.walletAddr();
 
         cut = new AaveV4RatioCheck();
+        paybackAction = new AaveV4Payback();
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                       FULL REPAY TESTS (targetRatio == 0)
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @notice Full repay leaves no debt, so Aave V4 reports health factor as max uint256.
+    function test_should_pass_full_repay_when_no_debt_left() public {
+        AaveV4TestPair[] memory tests = getTestPairs();
+        for (uint256 i = 0; i < tests.length; ++i) {
+            uint256 snapshotId = vm.snapshotState();
+
+            AaveV4TestPair memory testPair = tests[i];
+            if (!_executeAaveV4Open(testPair, 500, 100, wallet, false)) {
+                vm.revertToState(snapshotId);
+                continue;
+            }
+
+            uint256 startRatio = cut.getRatio(testPair.spoke, walletAddr);
+            assertLt(startRatio, type(uint256).max, "Position should have debt before full repay");
+
+            if (!_fullPayback(testPair)) {
+                vm.revertToState(snapshotId);
+                continue;
+            }
+
+            uint256 currRatio = cut.getRatio(testPair.spoke, walletAddr);
+            assertEq(currRatio, type(uint256).max, "Ratio should be max uint256 after full repay");
+
+            tempStorage.setBytes32(AAVE_V4_RATIO_KEY, bytes32(startRatio));
+            wallet.execute(address(cut), _ratioCheckCalldata(testPair.spoke, 0), 0);
+
+            vm.revertToState(snapshotId);
+        }
+    }
+
+    /// @notice With `targetRatio == 0` but debt still present, the check must revert.
+    function test_should_revert_full_repay_when_debt_left() public {
+        AaveV4TestPair[] memory tests = getTestPairs();
+        for (uint256 i = 0; i < tests.length; ++i) {
+            uint256 snapshotId = vm.snapshotState();
+
+            AaveV4TestPair memory testPair = tests[i];
+            if (!_executeAaveV4Open(testPair, 500, 100, wallet, false)) {
+                vm.revertToState(snapshotId);
+                continue;
+            }
+
+            uint256 currRatio = cut.getRatio(testPair.spoke, walletAddr);
+            assertLt(currRatio, type(uint256).max, "Position should still have debt");
+
+            tempStorage.setBytes32(AAVE_V4_RATIO_KEY, bytes32(currRatio));
+
+            bytes memory paramsCalldata = AaveV4Encode.ratioCheck(
+                uint8(AaveV4RatioCheck.RatioState.IN_REPAY), 0, testPair.spoke, walletAddr
+            );
+            vm.expectRevert(
+                abi.encodeWithSelector(
+                    AaveV4RatioCheck.BadAfterRatio.selector, currRatio, currRatio
+                )
+            );
+            cut.executeAction(paramsCalldata, subData, paramMapping, returnValues);
+
+            vm.revertToState(snapshotId);
+        }
     }
 
     function test_shouldRevertIfRepayDoesNotIncreaseRatio() public {
@@ -168,5 +237,44 @@ contract TestAaveV4RatioCheck is AaveV4TestBase {
 
             vm.revertToState(snapshotId);
         }
+    }
+
+    function _fullPayback(AaveV4TestPair memory _testPair) internal returns (bool) {
+        ISpoke spoke = ISpoke(_testPair.spoke);
+        address underlying = spoke.getReserve(_testPair.debtReserveId).underlying;
+        uint256 userDebt = spoke.getUserTotalDebt(_testPair.debtReserveId, walletAddr);
+        if (userDebt == 0) {
+            return false;
+        }
+
+        give(underlying, sender, userDebt * 2);
+        approveAsSender(sender, underlying, walletAddr, userDebt * 2);
+
+        wallet.execute(
+            address(paybackAction),
+            executeActionCalldata(
+                AaveV4Encode.payback(
+                    _testPair.spoke, walletAddr, sender, _testPair.debtReserveId, type(uint256).max
+                ),
+                true
+            ),
+            0
+        );
+
+        assertEq(spoke.getUserTotalDebt(_testPair.debtReserveId, walletAddr), 0);
+        return true;
+    }
+
+    function _ratioCheckCalldata(address _spoke, uint256 _targetRatio)
+        internal
+        view
+        returns (bytes memory)
+    {
+        return executeActionCalldata(
+            AaveV4Encode.ratioCheck(
+                uint8(AaveV4RatioCheck.RatioState.IN_REPAY), _targetRatio, _spoke, walletAddr
+            ),
+            false
+        );
     }
 }

--- a/test-sol/actions/checkers/CompV3RatioCheck.t.sol
+++ b/test-sol/actions/checkers/CompV3RatioCheck.t.sol
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity =0.8.24;
+
+import { CompV3RatioCheck } from "../../../contracts/actions/checkers/CompV3RatioCheck.sol";
+import { CompV3Supply } from "../../../contracts/actions/compoundV3/CompV3Supply.sol";
+import { CompV3Borrow } from "../../../contracts/actions/compoundV3/CompV3Borrow.sol";
+import { CompV3Payback } from "../../../contracts/actions/compoundV3/CompV3Payback.sol";
+import { IComet } from "../../../contracts/interfaces/protocols/compoundV3/IComet.sol";
+import {
+    TransientStorageCancun
+} from "../../../contracts/utils/transient/TransientStorageCancun.sol";
+
+import { BaseTest } from "../../utils/BaseTest.sol";
+import { ActionsUtils } from "../../utils/ActionsUtils.sol";
+import { SmartWallet } from "../../utils/SmartWallet.sol";
+import { CompV3Encode } from "../../utils/encode/CompV3Encode.sol";
+import { Addresses } from "../../utils/helpers/MainnetAddresses.sol";
+
+contract TestCompV3RatioCheck is BaseTest, ActionsUtils {
+    /*//////////////////////////////////////////////////////////////////////////
+                               CONTRACT UNDER TEST
+    //////////////////////////////////////////////////////////////////////////*/
+    CompV3RatioCheck cut;
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                    VARIABLES
+    //////////////////////////////////////////////////////////////////////////*/
+    CompV3Supply supplyAction;
+    CompV3Borrow borrowAction;
+    CompV3Payback paybackAction;
+    SmartWallet wallet;
+    address walletAddr;
+    address sender;
+
+    address constant MARKET = Addresses.COMET_USDC;
+    address constant COLL = Addresses.WETH_ADDR;
+    address constant BASE = Addresses.USDC_ADDR;
+
+    /// @dev Mirrors CompV3RatioCheck.RATIO_OFFSET (5% acceptable offset).
+    uint256 internal constant RATIO_OFFSET = 5e16;
+    string internal constant COMP_RATIO_KEY = "COMP_RATIO";
+
+    TransientStorageCancun constant tempStorage =
+        TransientStorageCancun(Addresses.TRANSIENT_STORAGE_CANCUN);
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                  SETUP FUNCTION
+    //////////////////////////////////////////////////////////////////////////*/
+    function setUp() public override {
+        forkFromEnv("");
+
+        wallet = new SmartWallet(bob);
+        sender = wallet.owner();
+        walletAddr = wallet.walletAddr();
+
+        cut = new CompV3RatioCheck();
+        supplyAction = new CompV3Supply();
+        borrowAction = new CompV3Borrow();
+        paybackAction = new CompV3Payback();
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                       FULL REPAY TESTS (targetRatio == 0)
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @notice Full repay leaves the position with no debt, so the safety ratio is 0.
+    ///         With `targetRatio == 0` (IN_REPAY) the check must pass.
+    function test_should_pass_full_repay_when_no_debt_left() public {
+        _createPosition();
+
+        uint256 startRatio = cut.getSafetyRatio(MARKET, walletAddr);
+        assertGt(startRatio, 0, "Position should have debt before full repay");
+
+        _fullPayback();
+
+        uint256 currRatio = cut.getSafetyRatio(MARKET, walletAddr);
+        assertEq(currRatio, 0, "Ratio should be 0 after full repay");
+
+        tempStorage.setBytes32(COMP_RATIO_KEY, bytes32(startRatio));
+        // Should not revert: target is 0 and there is no debt left.
+        wallet.execute(
+            address(cut), _ratioCheckCalldata(CompV3RatioCheck.RatioState.IN_REPAY, 0), 0
+        );
+    }
+
+    /// @notice With `targetRatio == 0` but debt still present, the check must revert.
+    function test_should_revert_full_repay_when_debt_left() public {
+        _createPosition();
+
+        uint256 currRatio = cut.getSafetyRatio(MARKET, walletAddr);
+        assertGt(currRatio, 0, "Position should still have debt");
+
+        uint256 startRatio = currRatio;
+        tempStorage.setBytes32(COMP_RATIO_KEY, bytes32(startRatio));
+
+        (bytes memory paramsCalldata, uint8[] memory pm) =
+            _checkParams(CompV3RatioCheck.RatioState.IN_REPAY, 0);
+        vm.expectRevert(
+            abi.encodeWithSelector(CompV3RatioCheck.BadAfterRatio.selector, startRatio, currRatio)
+        );
+        cut.executeAction(paramsCalldata, subData, pm, returnValues);
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                       NORMAL REPAY TESTS
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @notice Non-zero target where the ratio improved and stays within offset must pass.
+    function test_should_pass_normal_repay_within_offset() public {
+        _createPosition();
+
+        uint256 currRatio = cut.getSafetyRatio(MARKET, walletAddr);
+        // startRatio < currRatio (repay improved it), target == currRatio (within offset).
+        tempStorage.setBytes32(COMP_RATIO_KEY, bytes32(currRatio - 1e17));
+        wallet.execute(
+            address(cut), _ratioCheckCalldata(CompV3RatioCheck.RatioState.IN_REPAY, currRatio), 0
+        );
+    }
+
+    /// @notice Repay that overshoots `target + offset` must revert
+    function test_should_revert_normal_repay_overshoot() public {
+        _createPosition();
+
+        uint256 currRatio = cut.getSafetyRatio(MARKET, walletAddr);
+        uint256 startRatio = currRatio - 1e17;
+        uint256 targetRatio = currRatio - 2 * RATIO_OFFSET; // currRatio > targetRatio + offset
+
+        tempStorage.setBytes32(COMP_RATIO_KEY, bytes32(startRatio));
+        (bytes memory paramsCalldata, uint8[] memory pm) =
+            _checkParams(CompV3RatioCheck.RatioState.IN_REPAY, targetRatio);
+        vm.expectRevert(
+            abi.encodeWithSelector(CompV3RatioCheck.BadAfterRatio.selector, startRatio, currRatio)
+        );
+        cut.executeAction(paramsCalldata, subData, pm, returnValues);
+    }
+
+    /// @notice Repay that does not improve the ratio (currRatio <= startRatio) must revert.
+    function test_should_revert_normal_repay_no_improvement() public {
+        _createPosition();
+
+        uint256 currRatio = cut.getSafetyRatio(MARKET, walletAddr);
+        uint256 startRatio = currRatio;
+
+        tempStorage.setBytes32(COMP_RATIO_KEY, bytes32(startRatio));
+        (bytes memory paramsCalldata, uint8[] memory pm) =
+            _checkParams(CompV3RatioCheck.RatioState.IN_REPAY, currRatio);
+        vm.expectRevert(
+            abi.encodeWithSelector(CompV3RatioCheck.BadAfterRatio.selector, startRatio, currRatio)
+        );
+        cut.executeAction(paramsCalldata, subData, pm, returnValues);
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                     HELPERS
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @dev Opens a ~100k coll / ~40k debt Compound V3 position owned by the wallet.
+    function _createPosition() internal {
+        uint256 collAmount = amountInUSDPrice(COLL, 100_000);
+        give(COLL, walletAddr, collAmount);
+        wallet.execute(
+            address(supplyAction),
+            executeActionCalldata(CompV3Encode.supply(MARKET, COLL, collAmount, walletAddr), true),
+            0
+        );
+
+        uint256 borrowAmount = amountInUSDPrice(BASE, 40_000);
+        wallet.execute(
+            address(borrowAction),
+            executeActionCalldata(CompV3Encode.borrow(MARKET, borrowAmount, walletAddr), true),
+            0
+        );
+    }
+
+    /// @dev Fully pays back the wallet's base-token debt, leaving the collateral.
+    function _fullPayback() internal {
+        uint256 debt = IComet(MARKET).borrowBalanceOf(walletAddr);
+        // Fund the wallet with more than the debt to cover any accrued interest.
+        give(BASE, walletAddr, debt * 2);
+        wallet.execute(
+            address(paybackAction),
+            executeActionCalldata(
+                CompV3Encode.payback(MARKET, walletAddr, type(uint256).max), true
+            ),
+            0
+        );
+        assertEq(IComet(MARKET).borrowBalanceOf(walletAddr), 0, "Debt not fully repaid");
+    }
+
+    /// @dev Calldata to run the check through the wallet (delegatecall => user defaults to wallet).
+    function _ratioCheckCalldata(CompV3RatioCheck.RatioState _state, uint256 _targetRatio)
+        internal
+        view
+        returns (bytes memory)
+    {
+        return executeActionCalldata(
+            CompV3Encode.ratioCheck(uint8(_state), _targetRatio, MARKET), false
+        );
+    }
+
+    /// @dev Builds the check params (with user = wallet) and a length-4 paramMapping so the
+    ///      action honors the `user` param when the check is called directly.
+    function _checkParams(CompV3RatioCheck.RatioState _state, uint256 _targetRatio)
+        internal
+        view
+        returns (bytes memory paramsCalldata, uint8[] memory pm)
+    {
+        paramsCalldata = abi.encode(
+            CompV3RatioCheck.Params({
+                ratioState: _state, targetRatio: _targetRatio, market: MARKET, user: walletAddr
+            })
+        );
+        pm = new uint8[](4);
+    }
+}

--- a/test-sol/actions/checkers/MorphoBlueTargetRatioCheck.t.sol
+++ b/test-sol/actions/checkers/MorphoBlueTargetRatioCheck.t.sol
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity =0.8.24;
+
+import {
+    MorphoBlueTargetRatioCheck
+} from "../../../contracts/actions/checkers/MorphoBlueTargetRatioCheck.sol";
+import {
+    MorphoBlueSupplyCollateral
+} from "../../../contracts/actions/morpho-blue/MorphoBlueSupplyCollateral.sol";
+import { MorphoBlueBorrow } from "../../../contracts/actions/morpho-blue/MorphoBlueBorrow.sol";
+import { MorphoBluePayback } from "../../../contracts/actions/morpho-blue/MorphoBluePayback.sol";
+import { MarketParams } from "../../../contracts/interfaces/protocols/morpho-blue/IMorphoBlue.sol";
+
+import { BaseTest } from "../../utils/BaseTest.sol";
+import { ActionsUtils } from "../../utils/ActionsUtils.sol";
+import { SmartWallet } from "../../utils/SmartWallet.sol";
+import { Addresses } from "../../utils/helpers/MainnetAddresses.sol";
+
+contract TestMorphoBlueTargetRatioCheck is BaseTest, ActionsUtils {
+    /*//////////////////////////////////////////////////////////////////////////
+                               CONTRACT UNDER TEST
+    //////////////////////////////////////////////////////////////////////////*/
+    MorphoBlueTargetRatioCheck cut;
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                    VARIABLES
+    //////////////////////////////////////////////////////////////////////////*/
+    MorphoBlueSupplyCollateral supplyAction;
+    MorphoBlueBorrow borrowAction;
+    MorphoBluePayback paybackAction;
+    SmartWallet wallet;
+    address walletAddr;
+    address sender;
+
+    /// @dev Mirrors MorphoBlueTargetRatioCheck.RATIO_OFFSET (5% acceptable offset).
+    uint256 internal constant RATIO_OFFSET = 5e16;
+
+    /// @dev wstETH / WETH mainnet Morpho Blue market.
+    MarketParams market;
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                  SETUP FUNCTION
+    //////////////////////////////////////////////////////////////////////////*/
+    function setUp() public override {
+        forkFromEnv("");
+
+        wallet = new SmartWallet(bob);
+        sender = wallet.owner();
+        walletAddr = wallet.walletAddr();
+
+        cut = new MorphoBlueTargetRatioCheck();
+        supplyAction = new MorphoBlueSupplyCollateral();
+        borrowAction = new MorphoBlueBorrow();
+        paybackAction = new MorphoBluePayback();
+
+        market = MarketParams({
+            loanToken: Addresses.WETH_ADDR,
+            collateralToken: Addresses.WSTETH_ADDR,
+            oracle: 0xbD60A6770b27E084E8617335ddE769241B0e71D8,
+            irm: 0x870aC11D48B15DB9a138Cf899d20F13F79Ba00BC,
+            lltv: 965_000_000_000_000_000
+        });
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                       FULL REPAY TESTS (targetRatio == 0)
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @notice Full repay leaves the position with no debt, so the ratio is 0.
+    ///         With `targetRatio == 0` the check must pass.
+    function test_should_pass_full_repay_when_no_debt_left() public {
+        _createPosition();
+
+        uint256 startRatio = cut.getRatioUsingParams(market, walletAddr);
+        assertGt(startRatio, 0, "Position should have debt before full repay");
+
+        _fullPayback();
+
+        uint256 currRatio = cut.getRatioUsingParams(market, walletAddr);
+        assertEq(currRatio, 0, "Ratio should be 0 after full repay");
+
+        // Should not revert: target is 0 and there is no debt left.
+        wallet.execute(address(cut), _checkCalldata(0), 0);
+    }
+
+    /// @notice With `targetRatio == 0` but debt still present, the check must revert.
+    function test_should_revert_full_repay_when_debt_left() public {
+        _createPosition();
+
+        uint256 currRatio = cut.getRatioUsingParams(market, walletAddr);
+        assertGt(currRatio, 0, "Position should still have debt");
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                MorphoBlueTargetRatioCheck.BadAfterRatio.selector, currRatio, uint256(0)
+            )
+        );
+        cut.executeAction(_encodeCheck(0), subData, paramMapping, returnValues);
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                       NORMAL TARGET TESTS
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @notice Non-zero target within the 5% offset still passes (the non full repay branch).
+    function test_should_pass_normal_target_within_offset() public {
+        _createPosition();
+
+        uint256 currRatio = cut.getRatioUsingParams(market, walletAddr);
+        // target == currRatio => trivially within the accepted offset.
+        wallet.execute(address(cut), _checkCalldata(currRatio), 0);
+    }
+
+    /// @notice Non-zero target below the 5% offset must revert.
+    function test_should_revert_normal_target_below_offset() public {
+        _createPosition();
+
+        uint256 currRatio = cut.getRatioUsingParams(market, walletAddr);
+        // currRatio > targetRatio + RATIO_OFFSET => revert.
+        uint256 targetRatio = currRatio - 2 * RATIO_OFFSET;
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                MorphoBlueTargetRatioCheck.BadAfterRatio.selector, currRatio, targetRatio
+            )
+        );
+        cut.executeAction(_encodeCheck(targetRatio), subData, paramMapping, returnValues);
+    }
+
+    /// @notice Non-zero target above the 5% offset must revert.
+    function test_should_revert_normal_target_above_offset() public {
+        _createPosition();
+
+        uint256 currRatio = cut.getRatioUsingParams(market, walletAddr);
+        // currRatio < targetRatio - RATIO_OFFSET => revert.
+        uint256 targetRatio = currRatio + 2 * RATIO_OFFSET;
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                MorphoBlueTargetRatioCheck.BadAfterRatio.selector, currRatio, targetRatio
+            )
+        );
+        cut.executeAction(_encodeCheck(targetRatio), subData, paramMapping, returnValues);
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                     HELPERS
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @dev Opens a 20 wstETH coll / 10 WETH debt Morpho Blue position owned by the wallet.
+    function _createPosition() internal {
+        uint256 collAmount = 20 ether;
+        give(market.collateralToken, walletAddr, collAmount);
+        wallet.execute(
+            address(supplyAction),
+            executeActionCalldata(
+                abi.encode(
+                    MorphoBlueSupplyCollateral.Params({
+                        marketParams: market,
+                        supplyAmount: collAmount,
+                        from: walletAddr,
+                        onBehalf: address(0)
+                    })
+                ),
+                true
+            ),
+            0
+        );
+
+        uint256 borrowAmount = 10 ether;
+        wallet.execute(
+            address(borrowAction),
+            executeActionCalldata(
+                abi.encode(
+                    MorphoBlueBorrow.Params({
+                        marketParams: market,
+                        borrowAmount: borrowAmount,
+                        onBehalf: address(0),
+                        to: walletAddr
+                    })
+                ),
+                true
+            ),
+            0
+        );
+    }
+
+    /// @dev Fully pays back the wallet's loan-token debt, leaving the collateral.
+    function _fullPayback() internal {
+        // Fund the wallet with more than the debt to cover any accrued interest.
+        give(market.loanToken, walletAddr, 30 ether);
+        wallet.execute(
+            address(paybackAction),
+            executeActionCalldata(
+                abi.encode(
+                    MorphoBluePayback.Params({
+                        marketParams: market,
+                        paybackAmount: type(uint256).max,
+                        from: walletAddr,
+                        onBehalf: address(0)
+                    })
+                ),
+                true
+            ),
+            0
+        );
+    }
+
+    function _encodeCheck(uint256 _targetRatio) internal view returns (bytes memory) {
+        return abi.encode(
+            MorphoBlueTargetRatioCheck.Params({
+                marketParams: market, user: walletAddr, targetRatio: _targetRatio
+            })
+        );
+    }
+
+    function _checkCalldata(uint256 _targetRatio) internal view returns (bytes memory) {
+        return executeActionCalldata(_encodeCheck(_targetRatio), false);
+    }
+}

--- a/test-sol/actions/checkers/SparkTargetRatioCheck.t.sol
+++ b/test-sol/actions/checkers/SparkTargetRatioCheck.t.sol
@@ -1,0 +1,215 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity =0.8.24;
+
+import {
+    SparkTargetRatioCheck
+} from "../../../contracts/actions/checkers/SparkTargetRatioCheck.sol";
+import { SparkPayback } from "../../../contracts/actions/spark/SparkPayback.sol";
+import { SparkRatioHelper } from "../../../contracts/actions/spark/helpers/SparkRatioHelper.sol";
+import { ActionBase } from "../../../contracts/actions/ActionBase.sol";
+import { SparkDataTypes } from "../../../contracts/interfaces/protocols/spark/SparkDataTypes.sol";
+
+import { BaseTest } from "../../utils/BaseTest.sol";
+import { SmartWallet } from "../../utils/SmartWallet.sol";
+import { SparkPositionCreator } from "../../utils/positions/SparkPositionCreator.sol";
+import { SparkEncode } from "../../utils/encode/SparkEncode.sol";
+import { console2 } from "forge-std/console2.sol";
+
+/// @title Unit tests for SparkTargetRatioCheck.
+/// @notice Focused on the full repay support, where `targetRatio == 0` means the strategy
+///         must leave the position with no debt (ratio == 0) and keep the extra collateral.
+contract TestSparkTargetRatioCheck is SparkRatioHelper, SparkPositionCreator {
+    /*//////////////////////////////////////////////////////////////////////////
+                               CONTRACT UNDER TEST
+    //////////////////////////////////////////////////////////////////////////*/
+    SparkTargetRatioCheck cut;
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                    VARIABLES
+    //////////////////////////////////////////////////////////////////////////*/
+    SparkPayback paybackAction;
+    SmartWallet wallet;
+    address walletAddr;
+    address sender;
+
+    /// @dev Mirrors SparkTargetRatioCheck.RATIO_OFFSET (5% acceptable offset).
+    uint256 internal constant RATIO_OFFSET = 5e16;
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                  SETUP FUNCTION
+    //////////////////////////////////////////////////////////////////////////*/
+    function setUp() public override {
+        forkFromEnv("");
+        initTestPairs("Spark");
+
+        wallet = new SmartWallet(bob);
+        sender = wallet.owner();
+        walletAddr = wallet.walletAddr();
+
+        SparkPositionCreator.setUp();
+        cut = new SparkTargetRatioCheck();
+        paybackAction = new SparkPayback();
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                       FULL REPAY TESTS (targetRatio == 0)
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @notice Full repay leaves the position with no debt, so the safety ratio is 0.
+    ///         With `targetRatio == 0` the check must pass.
+    function test_should_pass_full_repay_when_no_debt_left() public {
+        for (uint256 i = 0; i < testPairs.length; ++i) {
+            uint256 snapshotId = vm.snapshotState();
+
+            if (_createPositionOrSkip(i) && _fullPayback(testPairs[i].borrowAsset)) {
+                uint256 currRatio = cut.getRatio(DEFAULT_SPARK_MARKET, walletAddr);
+                assertEq(currRatio, 0, "Ratio should be 0 after full repay");
+
+                wallet.execute(address(cut), _checkCalldata(0), 0);
+            }
+
+            vm.revertToState(snapshotId);
+        }
+    }
+
+    /// @notice With `targetRatio == 0` but debt still present, the check must revert,
+    ///         since a full repay strategy is only allowed to finish with no debt.
+    function test_should_revert_full_repay_when_debt_left() public {
+        for (uint256 i = 0; i < testPairs.length; ++i) {
+            uint256 snapshotId = vm.snapshotState();
+
+            if (_createPositionOrSkip(i)) {
+                uint256 currRatio = cut.getRatio(DEFAULT_SPARK_MARKET, walletAddr);
+                assertGt(currRatio, 0, "Position should still have debt");
+
+                vm.expectRevert();
+                wallet.execute(address(cut), _checkCalldata(0), 0);
+            }
+
+            vm.revertToState(snapshotId);
+        }
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                       NORMAL TARGET TESTS (regression)
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @notice Non-zero target within the 5% offset still passes (the non full repay branch).
+    function test_should_pass_normal_target_within_offset() public {
+        for (uint256 i = 0; i < testPairs.length; ++i) {
+            uint256 snapshotId = vm.snapshotState();
+
+            if (_createPositionOrSkip(i)) {
+                uint256 currRatio = cut.getRatio(DEFAULT_SPARK_MARKET, walletAddr);
+                wallet.execute(address(cut), _checkCalldata(currRatio), 0);
+            }
+
+            vm.revertToState(snapshotId);
+        }
+    }
+
+    /// @notice Non-zero target below the 5% offset must revert (the non full repay branch).
+    function test_should_revert_normal_target_below_offset() public {
+        for (uint256 i = 0; i < testPairs.length; ++i) {
+            uint256 snapshotId = vm.snapshotState();
+
+            if (_createPositionOrSkip(i)) {
+                uint256 currRatio = cut.getRatio(DEFAULT_SPARK_MARKET, walletAddr);
+                uint256 targetRatio = currRatio - 2 * RATIO_OFFSET;
+
+                vm.expectRevert();
+                wallet.execute(address(cut), _checkCalldata(targetRatio), 0);
+            }
+
+            vm.revertToState(snapshotId);
+        }
+    }
+
+    /// @notice Non-zero target above the 5% offset must revert (the non full repay branch).
+    function test_should_revert_normal_target_above_offset() public {
+        for (uint256 i = 0; i < testPairs.length; ++i) {
+            uint256 snapshotId = vm.snapshotState();
+
+            if (_createPositionOrSkip(i)) {
+                uint256 currRatio = cut.getRatio(DEFAULT_SPARK_MARKET, walletAddr);
+                uint256 targetRatio = currRatio + 2 * RATIO_OFFSET;
+
+                vm.expectRevert();
+                wallet.execute(address(cut), _checkCalldata(targetRatio), 0);
+            }
+
+            vm.revertToState(snapshotId);
+        }
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                     HELPERS
+    //////////////////////////////////////////////////////////////////////////*/
+
+    function _createPositionOrSkip(uint256 _i) internal returns (bool) {
+        PositionParams memory positionParams = PositionParams({
+            collAddr: testPairs[_i].supplyAsset,
+            collAmount: amountInUSDPrice(testPairs[_i].supplyAsset, 100_000),
+            debtAddr: testPairs[_i].borrowAsset,
+            debtAmount: amountInUSDPrice(testPairs[_i].borrowAsset, 40_000)
+        });
+
+        if (!isValidSupply(
+                DEFAULT_SPARK_MARKET, positionParams.collAddr, positionParams.collAmount
+            )) {
+            console2.log("[SparkTargetRatioCheck] Can't supply asset. Skipping pair...");
+            return false;
+        }
+        if (!isValidBorrow(
+                DEFAULT_SPARK_MARKET, positionParams.debtAddr, positionParams.debtAmount
+            )) {
+            console2.log("[SparkTargetRatioCheck] Can't borrow asset. Skipping pair...");
+            return false;
+        }
+
+        createSparkPosition(positionParams, wallet);
+        return true;
+    }
+
+    function _fullPayback(address _debtAddr) internal returns (bool) {
+        if (!isValidRepay(DEFAULT_SPARK_MARKET, _debtAddr)) {
+            console2.log("[SparkTargetRatioCheck] Can't repay asset. Skipping pair...");
+            return false;
+        }
+
+        SparkDataTypes.ReserveData memory reserveData = pool.getReserveData(_debtAddr);
+        uint16 debtAssetId = reserveData.id;
+        address debtVariableTokenAddr = reserveData.variableDebtTokenAddress;
+
+        uint256 walletVariableDebt = balanceOf(debtVariableTokenAddr, walletAddr);
+
+        give(_debtAddr, sender, walletVariableDebt * 2);
+        approveAsSender(sender, _debtAddr, walletAddr, walletVariableDebt * 2);
+
+        bytes memory paramsCalldata = SparkEncode.payback(
+            type(uint256).max, sender, 2, debtAssetId, true, false, address(0), address(0)
+        );
+        bytes memory _calldata = abi.encodeWithSelector(
+            SparkPayback.executeAction.selector, paramsCalldata, subData, paramMapping, returnValues
+        );
+        wallet.execute(address(paybackAction), _calldata, 0);
+
+        (uint256 totalCollateralBase, uint256 totalDebtBase,,,,) =
+            pool.getUserAccountData(walletAddr);
+        assertEq(totalDebtBase, 0, "Debt not fully repaid");
+        assertGt(totalCollateralBase, 0, "Collateral should remain after full repay");
+        return true;
+    }
+
+    function _checkCalldata(uint256 _targetRatio) internal view returns (bytes memory) {
+        bytes memory paramsCalldata = abi.encode(
+            SparkTargetRatioCheck.Params({
+                targetRatio: _targetRatio, market: DEFAULT_SPARK_MARKET
+            })
+        );
+        return abi.encodeWithSelector(
+            ActionBase.executeAction.selector, paramsCalldata, subData, paramMapping, returnValues
+        );
+    }
+}

--- a/test-sol/config/config.json
+++ b/test-sol/config/config.json
@@ -34,6 +34,15 @@
     "AaveV3View": { "mainnet": 24741489 },
     "AaveV3RatioHelper": { "mainnet": 25250678 },
     "ETH-ltv0": { "mainnet": 24929244 },
+    "Spark": {
+        "lightTesting": false,
+        "lightPairs": [{ "supplyAsset": "WETH", "borrowAsset": "USDC" }],
+        "fullPairs": [
+            { "supplyAsset": "WETH", "borrowAsset": "USDC" },
+            { "supplyAsset": "WETH", "borrowAsset": "USDT" },
+            { "supplyAsset": "WBTC", "borrowAsset": "USDT" }
+        ]
+    },
     "AaveV3": {
         "lightTesting": false,
         "lightPairs": [{ "supplyAsset": "WETH", "borrowAsset": "DAI" }],

--- a/test-sol/config/config.json
+++ b/test-sol/config/config.json
@@ -33,6 +33,7 @@
     "CompV3EOAAutomation": { "mainnet": 24741489 },
     "AaveV3View": { "mainnet": 24741489 },
     "AaveV3RatioHelper": { "mainnet": 25250678 },
+    "ETH-ltv0": { "mainnet": 24929244 },
     "AaveV3": {
         "lightTesting": false,
         "lightPairs": [{ "supplyAsset": "WETH", "borrowAsset": "DAI" }],

--- a/test-sol/utils/encode/SparkEncode.sol
+++ b/test-sol/utils/encode/SparkEncode.sol
@@ -3,6 +3,7 @@ pragma solidity =0.8.24;
 
 import { SparkSupply } from "../../../contracts/actions/spark/SparkSupply.sol";
 import { SparkBorrow } from "../../../contracts/actions/spark/SparkBorrow.sol";
+import { SparkPayback } from "../../../contracts/actions/spark/SparkPayback.sol";
 import { SparkSetEMode } from "../../../contracts/actions/spark/SparkSetEMode.sol";
 
 library SparkEncode {
@@ -44,6 +45,30 @@ library SparkEncode {
             SparkBorrow.Params({
                 amount: _amount,
                 to: _to,
+                rateMode: _rateMode,
+                assetId: _assetId,
+                useDefaultMarket: _useDefaultMarket,
+                useOnBehalf: _useOnBehalf,
+                market: _market,
+                onBehalf: _onBehalf
+            })
+        );
+    }
+
+    function payback(
+        uint256 _amount,
+        address _from,
+        uint8 _rateMode,
+        uint16 _assetId,
+        bool _useDefaultMarket,
+        bool _useOnBehalf,
+        address _market,
+        address _onBehalf
+    ) public pure returns (bytes memory params) {
+        params = abi.encode(
+            SparkPayback.Params({
+                amount: _amount,
+                from: _from,
                 rateMode: _rateMode,
                 assetId: _assetId,
                 useDefaultMarket: _useDefaultMarket,

--- a/test-sol/utils/executeActions/SparkExecuteActions.sol
+++ b/test-sol/utils/executeActions/SparkExecuteActions.sol
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity =0.8.24;
+
+import { ExecuteActionsBase } from "./ExecuteActionsBase.sol";
+import { SmartWallet } from "../SmartWallet.sol";
+import { SparkSupply } from "../../../contracts/actions/spark/SparkSupply.sol";
+import { SparkBorrow } from "../../../contracts/actions/spark/SparkBorrow.sol";
+import { SparkEncode } from "../encode/SparkEncode.sol";
+
+contract SparkExecuteActions is ExecuteActionsBase {
+    function executeSparkSupply(
+        SparkSupply.Params memory _params,
+        address _supplyToken,
+        SmartWallet _wallet,
+        bool _useAddressFromDfsRegistry,
+        address _contractAddress
+    ) public {
+        bytes memory paramsCalldata = SparkEncode.supply(
+            _params.amount,
+            _params.from,
+            _params.assetId,
+            _params.enableAsColl,
+            _params.useDefaultMarket,
+            _params.useOnBehalf,
+            _params.market,
+            _params.onBehalf
+        );
+        bytes memory _calldata =
+            abi.encodeWithSelector(EXECUTE_ACTION_DIRECT_SELECTOR, paramsCalldata);
+        address target = _useAddressFromDfsRegistry ? getAddr("SparkSupply") : _contractAddress;
+
+        give(_supplyToken, _wallet.owner(), _params.amount);
+        _wallet.ownerApprove(_supplyToken, _params.amount);
+        _wallet.execute(target, _calldata, 0);
+    }
+
+    function executeSparkBorrow(
+        SparkBorrow.Params memory _params,
+        SmartWallet _wallet,
+        bool _useAddressFromDfsRegistry,
+        address _contractAddress
+    ) public {
+        bytes memory paramsCalldata = SparkEncode.borrow(
+            _params.amount,
+            _params.to,
+            _params.rateMode,
+            _params.assetId,
+            _params.useDefaultMarket,
+            _params.useOnBehalf,
+            _params.market,
+            _params.onBehalf
+        );
+        bytes memory _calldata =
+            abi.encodeWithSelector(EXECUTE_ACTION_DIRECT_SELECTOR, paramsCalldata);
+        address target = _useAddressFromDfsRegistry ? getAddr("SparkBorrow") : _contractAddress;
+
+        _wallet.execute(target, _calldata, 0);
+    }
+}

--- a/test-sol/utils/positions/SparkPositionCreator.sol
+++ b/test-sol/utils/positions/SparkPositionCreator.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity =0.8.24;
+
+import { CommonPositionCreator } from "./CommonPositionCreator.sol";
+import { SparkExecuteActions } from "../../utils/executeActions/SparkExecuteActions.sol";
+import { SparkTestHelper } from "../spark/SparkTestHelper.sol";
+import { SparkSupply } from "../../../contracts/actions/spark/SparkSupply.sol";
+import { SparkBorrow } from "../../../contracts/actions/spark/SparkBorrow.sol";
+import { ISparkPool } from "../../../contracts/interfaces/protocols/spark/ISparkPool.sol";
+import { SparkDataTypes } from "../../../contracts/interfaces/protocols/spark/SparkDataTypes.sol";
+import { SmartWallet } from "../SmartWallet.sol";
+
+/// @notice Contract for creating positions on Spark with default values for common parameters.
+contract SparkPositionCreator is SparkExecuteActions, SparkTestHelper, CommonPositionCreator {
+    ISparkPool pool;
+
+    function setUp() public virtual override {
+        pool = getSparkLendingPool(DEFAULT_SPARK_MARKET);
+    }
+
+    function createSparkPosition(PositionParams memory _params, SmartWallet _wallet) public {
+        SparkDataTypes.ReserveData memory supplyData = pool.getReserveData(_params.collAddr);
+        SparkDataTypes.ReserveData memory borrowData = pool.getReserveData(_params.debtAddr);
+
+        SparkSupply.Params memory supplyParams = SparkSupply.Params({
+            amount: _params.collAmount,
+            from: _wallet.owner(),
+            assetId: supplyData.id,
+            enableAsColl: true,
+            useDefaultMarket: true,
+            useOnBehalf: false,
+            market: address(0),
+            onBehalf: address(0)
+        });
+        SparkBorrow.Params memory borrowParams = SparkBorrow.Params({
+            amount: _params.debtAmount,
+            to: _wallet.owner(),
+            rateMode: 2,
+            assetId: borrowData.id,
+            useDefaultMarket: true,
+            useOnBehalf: false,
+            market: address(0),
+            onBehalf: address(0)
+        });
+
+        executeSparkSupply(
+            supplyParams, _params.collAddr, _wallet, false, address(new SparkSupply())
+        );
+        executeSparkBorrow(borrowParams, _wallet, false, address(new SparkBorrow()));
+    }
+}

--- a/test-sol/utils/spark/SparkTestHelper.sol
+++ b/test-sol/utils/spark/SparkTestHelper.sol
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: MIT
+pragma solidity =0.8.24;
+
+import { IERC20 } from "../../../contracts/interfaces/token/IERC20.sol";
+import { ISparkPool } from "../../../contracts/interfaces/protocols/spark/ISparkPool.sol";
+import { SparkDataTypes } from "../../../contracts/interfaces/protocols/spark/SparkDataTypes.sol";
+import { DataTypes } from "../../../contracts/interfaces/protocols/aaveV3/DataTypes.sol";
+import { ReserveConfiguration } from "../../../contracts/_vendor/aave/v3/ReserveConfiguration.sol";
+import { SparkHelper } from "../../../contracts/actions/spark/helpers/SparkHelper.sol";
+
+contract SparkTestHelper is SparkHelper {
+    using ReserveConfiguration for DataTypes.ReserveConfigurationMap;
+
+    function isValidSupply(address _market, address _token, uint256 _amount)
+        public
+        view
+        returns (bool)
+    {
+        if (_amount == 0) return false;
+
+        ISparkPool lendingPool = getSparkLendingPool(_market);
+        SparkDataTypes.ReserveData memory reserve = lendingPool.getReserveData(_token);
+        DataTypes.ReserveConfigurationMap memory config;
+        config.data = reserve.configuration.data;
+
+        (bool isActive, bool isFrozen,, bool isPaused) = config.getFlags();
+        if (!isActive) return false;
+        if (isFrozen) return false;
+        if (isPaused) return false;
+
+        uint256 supplyCap = config.getSupplyCap() * (10 ** config.getDecimals());
+        uint256 aTokenTotalSupply = IERC20(reserve.aTokenAddress).totalSupply();
+        if (supplyCap != 0 && supplyCap < aTokenTotalSupply + _amount) return false;
+
+        return true;
+    }
+
+    function isValidBorrow(address _market, address _token, uint256 _amount)
+        public
+        view
+        returns (bool)
+    {
+        if (_amount == 0) return false;
+
+        ISparkPool lendingPool = getSparkLendingPool(_market);
+        SparkDataTypes.ReserveData memory reserve = lendingPool.getReserveData(_token);
+        DataTypes.ReserveConfigurationMap memory config;
+        config.data = reserve.configuration.data;
+
+        (bool isActive, bool isFrozen, bool isBorrowingEnabled, bool isPaused) = config.getFlags();
+        if (!isActive) return false;
+        if (isFrozen) return false;
+        if (isPaused) return false;
+        if (!isBorrowingEnabled) return false;
+
+        uint256 borrowCap = config.getBorrowCap() * (10 ** config.getDecimals());
+        uint256 totalBorrow = IERC20(reserve.variableDebtTokenAddress).totalSupply();
+        if (borrowCap != 0 && borrowCap < totalBorrow + _amount) return false;
+
+        uint256 liquidity = IERC20(_token).balanceOf(reserve.aTokenAddress);
+        if (liquidity < _amount) return false;
+
+        return true;
+    }
+
+    function isValidRepay(address _market, address _token) public view returns (bool) {
+        ISparkPool lendingPool = getSparkLendingPool(_market);
+        SparkDataTypes.ReserveData memory reserve = lendingPool.getReserveData(_token);
+        DataTypes.ReserveConfigurationMap memory config;
+        config.data = reserve.configuration.data;
+
+        (bool isActive,,, bool isPaused) = config.getFlags();
+        if (!isActive) return false;
+        if (isPaused) return false;
+
+        return true;
+    }
+}

--- a/test/strategies/aaveV3/generic/full-repay-on-price.js
+++ b/test/strategies/aaveV3/generic/full-repay-on-price.js
@@ -1,0 +1,457 @@
+// AaveV3 Full Repay On Price strategies
+// Almost identical to ./repay-on-price.js, but uses targetRatio = 0 for everything.
+// With targetRatio 0 the strategy must fully repay the debt and leave the extra collateral
+// in the position (AaveV3OpenRatioCheck requires the resulting ratio to be exactly 0).
+const hre = require('hardhat');
+const { expect } = require('chai');
+const { getAssetInfo } = require('@defisaver/tokens');
+const automationSdk = require('@defisaver/automation-sdk');
+
+const {
+    getProxy,
+    network,
+    addrs,
+    takeSnapshot,
+    revertToSnapshot,
+    chainIds,
+    getContractFromRegistry,
+    getStrategyExecutorContract,
+    getAndSetMockExchangeWrapper,
+    formatMockExchangeObjUsdFeed,
+    fetchAmountInUSDPrice,
+    isNetworkFork,
+    redeploy,
+    sendEther,
+    addBalancerFlLiquidity,
+    balanceOf,
+} = require('../../../utils/utils');
+
+const { addBotCaller } = require('../../utils/utils-strategies');
+const { subAaveV3LeverageManagementOnPriceGeneric } = require('../../utils/strategy-subs');
+const {
+    callAaveV3GenericRepayOnPriceStrategy,
+    callAaveV3GenericFLRepayOnPriceStrategy,
+} = require('../../utils/strategy-calls');
+const {
+    openAaveV3ProxyPosition,
+    openAaveV3EOAPosition,
+    getAaveV3PositionRatio,
+    deployAaveV3RepayOnPriceGenericBundle,
+    setupAaveV3EOAPermissions,
+    getAaveV3ReserveData,
+} = require('../../../utils/aave');
+
+const TRIGGER_PRICE_UNDER = 999_999;
+const TRIGGER_PRICE_OVER = 0;
+const PRICE_STATE_UNDER = automationSdk.enums.RatioState.UNDER;
+const PRICE_STATE_OVER = automationSdk.enums.RatioState.OVER;
+
+// Full repay => target ratio is 0 (leave position with no debt).
+const FULL_REPAY_TARGET_RATIO = 0;
+
+// Amount of collateral to repay with, derived from the debt: 10% more than the debt so it
+// comfortably covers the whole debt (+ fee). Aave caps the payback at the actual debt.
+const fullRepayAmountInUSD = (debtAmountInUSD) => Math.floor(debtAmountInUSD * 1.1);
+
+// Dedicated low-leverage pairs for the full repay flow.
+// The (non-FL) repay-on-price recipe withdraws collateral BEFORE paying back the debt, so the
+// repay amount of collateral must be withdrawable while the full debt is still outstanding
+// without breaching Aave's health factor. We therefore use a small debt relative to the
+// collateral so the repay amount (debt + 10%) can be withdrawn while the position stays healthy.
+const FULL_REPAY_TEST_PAIRS = {
+    1: [
+        // Core Market pairs
+        {
+            collSymbol: 'WETH',
+            debtSymbol: 'DAI',
+            marketAddr: addrs[network].AAVE_MARKET,
+            collAmountInUSD: 50_000,
+            debtAmountInUSD: 8_000,
+        },
+        {
+            collSymbol: 'WETH',
+            debtSymbol: 'USDC',
+            marketAddr: addrs[network].AAVE_MARKET,
+            collAmountInUSD: 50_000,
+            debtAmountInUSD: 8_000,
+        },
+        {
+            collSymbol: 'WBTC',
+            debtSymbol: 'USDC',
+            marketAddr: addrs[network].AAVE_MARKET,
+            collAmountInUSD: 50_000,
+            debtAmountInUSD: 8_000,
+        },
+        // Prime Market pair
+        {
+            collSymbol: 'WETH',
+            debtSymbol: 'USDC',
+            marketAddr: addrs[network].AAVE_V3_PRIME_MARKET,
+            collAmountInUSD: 50_000,
+            debtAmountInUSD: 8_000,
+        },
+    ],
+};
+
+const runFullRepayOnPriceTests = () => {
+    describe('AaveV3 Full Repay On Price Strategies Tests', () => {
+        let snapshotId;
+        let senderAcc;
+        let proxy;
+        let botAcc;
+        let strategyExecutor;
+        let mockWrapper;
+        let flAddr;
+        let bundleId;
+
+        before(async () => {
+            // Setup
+            const isFork = isNetworkFork();
+            await hre.network.provider.send('hardhat_setNextBlockBaseFeePerGas', ['0x0']);
+
+            senderAcc = (await hre.ethers.getSigners())[0];
+            botAcc = (await hre.ethers.getSigners())[1];
+            await sendEther(senderAcc, addrs[network].OWNER_ACC, '10');
+            proxy = await getProxy(senderAcc.address);
+            await addBotCaller(botAcc.address, isFork);
+            strategyExecutor = (await getStrategyExecutorContract()).connect(botAcc);
+            mockWrapper = await getAndSetMockExchangeWrapper(senderAcc);
+
+            const flContract = await getContractFromRegistry('FLAction', isFork);
+            flAddr = flContract.address;
+
+            // Redeploys
+            await redeploy('AaveV3QuotePriceTrigger', isFork);
+            await redeploy('AaveV3Borrow', isFork);
+            await redeploy('AaveV3Payback', isFork);
+            await redeploy('AaveV3Supply', isFork);
+            await redeploy('AaveV3Withdraw', isFork);
+            await redeploy('AaveV3RatioCheck', isFork);
+            await redeploy('AaveV3OpenRatioCheck', isFork);
+            await redeploy('AaveV3View', isFork);
+            await redeploy('SubProxy', isFork);
+
+            bundleId = await deployAaveV3RepayOnPriceGenericBundle();
+        });
+
+        beforeEach(async () => {
+            snapshotId = await takeSnapshot();
+        });
+
+        afterEach(async () => {
+            await revertToSnapshot(snapshotId);
+        });
+
+        const baseTest = async (
+            collAsset,
+            debtAsset,
+            targetRatio,
+            collAmountInUSD,
+            debtAmountInUSD,
+            repayAmountInUSD,
+            isEOA,
+            isFLStrategy,
+            triggerPrice,
+            priceState,
+            marketAddress,
+        ) => {
+            const positionOwner = isEOA ? senderAcc.address : proxy.address;
+
+            // Open position
+            if (isEOA) {
+                await openAaveV3EOAPosition(
+                    senderAcc.address,
+                    proxy,
+                    collAsset.symbol,
+                    debtAsset.symbol,
+                    collAmountInUSD,
+                    debtAmountInUSD,
+                    marketAddress,
+                );
+
+                // EOA delegates to the actual Smart Wallet address that executes the strategy
+                await setupAaveV3EOAPermissions(
+                    senderAcc.address,
+                    proxy.address, // The actual Smart Wallet executing address
+                    collAsset.address,
+                    debtAsset.address,
+                    marketAddress,
+                );
+            } else {
+                await openAaveV3ProxyPosition(
+                    senderAcc.address,
+                    proxy,
+                    collAsset.symbol,
+                    debtAsset.symbol,
+                    collAmountInUSD,
+                    debtAmountInUSD,
+                    marketAddress,
+                );
+            }
+
+            // Check ratioBefore
+            const ratioBefore = await getAaveV3PositionRatio(positionOwner, null, marketAddress);
+            console.log('ratioBefore', ratioBefore);
+
+            // Get asset IDs
+            const collAssetId = (await getAaveV3ReserveData(collAsset.address, marketAddress)).id;
+            const debtAssetId = (await getAaveV3ReserveData(debtAsset.address, marketAddress)).id;
+
+            const user = isEOA ? senderAcc.address : proxy.address;
+
+            // Create subscription based on whether it's EOA or proxy
+            const result = await subAaveV3LeverageManagementOnPriceGeneric(
+                proxy,
+                user,
+                collAsset.address,
+                collAssetId,
+                debtAsset.address,
+                debtAssetId,
+                marketAddress,
+                targetRatio,
+                triggerPrice,
+                priceState,
+                bundleId,
+            );
+            const repaySubId = result.subId;
+            const strategySub = result.strategySub;
+
+            console.log('SUBBED !!!!');
+            // console.log(repaySubId, strategySub);
+
+            const repayAmount = await fetchAmountInUSDPrice(collAsset.symbol, repayAmountInUSD);
+            console.log(repayAmount);
+
+            const exchangeObject = await formatMockExchangeObjUsdFeed(
+                collAsset,
+                debtAsset,
+                repayAmount,
+                mockWrapper,
+            );
+
+            // Execute strategy
+            if (isFLStrategy) {
+                console.log('Executing FL Full Repay On Price strategy !!!!');
+                await addBalancerFlLiquidity(debtAsset.address);
+                await addBalancerFlLiquidity(collAsset.address);
+
+                await callAaveV3GenericFLRepayOnPriceStrategy(
+                    strategyExecutor,
+                    1,
+                    repaySubId,
+                    strategySub,
+                    exchangeObject,
+                    repayAmount,
+                    flAddr,
+                    marketAddress,
+                );
+            } else {
+                await callAaveV3GenericRepayOnPriceStrategy(
+                    strategyExecutor,
+                    0,
+                    repaySubId,
+                    strategySub,
+                    exchangeObject,
+                    repayAmount,
+                    marketAddress,
+                );
+            }
+
+            const ratioAfter = await getAaveV3PositionRatio(positionOwner, null, marketAddress);
+            console.log('ratioAfter', ratioAfter);
+            console.log('ratioBefore', ratioBefore);
+
+            // Full repay: the strategy must leave the position with no debt, so the safety
+            // ratio is exactly 0 (AaveV3OpenRatioCheck enforces this for targetRatio == 0).
+            expect(ratioAfter).to.be.eq(0);
+
+            // No debt should remain, while the leftover collateral stays in the position.
+            const collReserve = await getAaveV3ReserveData(collAsset.address, marketAddress);
+            const debtReserve = await getAaveV3ReserveData(debtAsset.address, marketAddress);
+            const debtBalanceAfter = await balanceOf(
+                debtReserve.variableDebtTokenAddress,
+                positionOwner,
+            );
+            const collBalanceAfter = await balanceOf(collReserve.aTokenAddress, positionOwner);
+            expect(debtBalanceAfter).to.be.eq(0);
+            expect(collBalanceAfter).to.be.gt(0);
+        };
+
+        const testPairs = FULL_REPAY_TEST_PAIRS[chainIds[network]] || [];
+        for (let i = 0; i < testPairs.length; ++i) {
+            const pair = testPairs[i];
+            const collAsset = getAssetInfo(
+                pair.collSymbol === 'ETH' ? 'WETH' : pair.collSymbol,
+                chainIds[network],
+            );
+            const debtAsset = getAssetInfo(
+                pair.debtSymbol === 'ETH' ? 'WETH' : pair.debtSymbol,
+                chainIds[network],
+            );
+
+            // Determine market name for test description
+            const marketName =
+                pair.marketAddr === addrs[network].AAVE_MARKET ? 'Core Market' : 'Prime Market';
+
+            it(`... should execute aaveV3 SW Full Repay on price strategy (UNDER) for ${pair.collSymbol} /
+            ${pair.debtSymbol} pair on Aave V3 ${marketName}`, async () => {
+                const isEOA = false;
+                const isFLStrategy = false;
+
+                await baseTest(
+                    collAsset,
+                    debtAsset,
+                    FULL_REPAY_TARGET_RATIO,
+                    pair.collAmountInUSD,
+                    pair.debtAmountInUSD,
+                    fullRepayAmountInUSD(pair.debtAmountInUSD),
+                    isEOA,
+                    isFLStrategy,
+                    TRIGGER_PRICE_UNDER,
+                    PRICE_STATE_UNDER,
+                    pair.marketAddr,
+                );
+            });
+
+            it(`... should execute aaveV3 SW Full Repay on price strategy (OVER) for ${pair.collSymbol} /
+            ${pair.debtSymbol} pair on Aave V3 ${marketName}`, async () => {
+                const isEOA = false;
+                const isFLStrategy = false;
+
+                await baseTest(
+                    collAsset,
+                    debtAsset,
+                    FULL_REPAY_TARGET_RATIO,
+                    pair.collAmountInUSD,
+                    pair.debtAmountInUSD,
+                    fullRepayAmountInUSD(pair.debtAmountInUSD),
+                    isEOA,
+                    isFLStrategy,
+                    TRIGGER_PRICE_OVER,
+                    PRICE_STATE_OVER,
+                    pair.marketAddr,
+                );
+            });
+
+            it(`... should execute aaveV3 SW FL Full Repay on price strategy (UNDER) for ${pair.collSymbol} /
+            ${pair.debtSymbol} pair on Aave V3 ${marketName}`, async () => {
+                const isEOA = false;
+                const isFLStrategy = true;
+
+                await baseTest(
+                    collAsset,
+                    debtAsset,
+                    FULL_REPAY_TARGET_RATIO,
+                    pair.collAmountInUSD,
+                    pair.debtAmountInUSD,
+                    fullRepayAmountInUSD(pair.debtAmountInUSD),
+                    isEOA,
+                    isFLStrategy,
+                    TRIGGER_PRICE_UNDER,
+                    PRICE_STATE_UNDER,
+                    pair.marketAddr,
+                );
+            });
+
+            it(`... should execute aaveV3 SW FL Full Repay on price strategy (OVER) for ${pair.collSymbol} /
+            ${pair.debtSymbol} pair on Aave V3 ${marketName}`, async () => {
+                const isEOA = false;
+                const isFLStrategy = true;
+
+                await baseTest(
+                    collAsset,
+                    debtAsset,
+                    FULL_REPAY_TARGET_RATIO,
+                    pair.collAmountInUSD,
+                    pair.debtAmountInUSD,
+                    fullRepayAmountInUSD(pair.debtAmountInUSD),
+                    isEOA,
+                    isFLStrategy,
+                    TRIGGER_PRICE_OVER,
+                    PRICE_STATE_OVER,
+                    pair.marketAddr,
+                );
+            });
+
+            it(`... should execute aaveV3 EOA Full Repay on price strategy (UNDER) for ${pair.collSymbol} / ${pair.debtSymbol} pair on Aave V3 ${marketName}`, async () => {
+                const isEOA = true;
+                const isFLStrategy = false;
+
+                await baseTest(
+                    collAsset,
+                    debtAsset,
+                    FULL_REPAY_TARGET_RATIO,
+                    pair.collAmountInUSD,
+                    pair.debtAmountInUSD,
+                    fullRepayAmountInUSD(pair.debtAmountInUSD),
+                    isEOA,
+                    isFLStrategy,
+                    TRIGGER_PRICE_UNDER,
+                    PRICE_STATE_UNDER,
+                    pair.marketAddr,
+                );
+            });
+
+            it(`... should execute aaveV3 EOA Full Repay on price strategy (OVER) for ${pair.collSymbol} / ${pair.debtSymbol} pair on Aave V3 ${marketName}`, async () => {
+                const isEOA = true;
+                const isFLStrategy = false;
+
+                await baseTest(
+                    collAsset,
+                    debtAsset,
+                    FULL_REPAY_TARGET_RATIO,
+                    pair.collAmountInUSD,
+                    pair.debtAmountInUSD,
+                    fullRepayAmountInUSD(pair.debtAmountInUSD),
+                    isEOA,
+                    isFLStrategy,
+                    TRIGGER_PRICE_OVER,
+                    PRICE_STATE_OVER,
+                    pair.marketAddr,
+                );
+            });
+
+            it(`... should execute aaveV3 EOA FL Full Repay on price strategy (UNDER) for ${pair.collSymbol} / ${pair.debtSymbol} pair on Aave V3 ${marketName}`, async () => {
+                const isEOA = true;
+                const isFLStrategy = true;
+
+                await baseTest(
+                    collAsset,
+                    debtAsset,
+                    FULL_REPAY_TARGET_RATIO,
+                    pair.collAmountInUSD,
+                    pair.debtAmountInUSD,
+                    fullRepayAmountInUSD(pair.debtAmountInUSD),
+                    isEOA,
+                    isFLStrategy,
+                    TRIGGER_PRICE_UNDER,
+                    PRICE_STATE_UNDER,
+                    pair.marketAddr,
+                );
+            });
+
+            it(`... should execute aaveV3 EOA FL Full Repay on price strategy (OVER) for ${pair.collSymbol} / ${pair.debtSymbol} pair on Aave V3 ${marketName}`, async () => {
+                const isEOA = true;
+                const isFLStrategy = true;
+
+                await baseTest(
+                    collAsset,
+                    debtAsset,
+                    FULL_REPAY_TARGET_RATIO,
+                    pair.collAmountInUSD,
+                    pair.debtAmountInUSD,
+                    fullRepayAmountInUSD(pair.debtAmountInUSD),
+                    isEOA,
+                    isFLStrategy,
+                    TRIGGER_PRICE_OVER,
+                    PRICE_STATE_OVER,
+                    pair.marketAddr,
+                );
+            });
+        }
+    });
+};
+
+module.exports = {
+    runFullRepayOnPriceTests,
+};

--- a/test/strategies/aaveV3/generic/full-test.js
+++ b/test/strategies/aaveV3/generic/full-test.js
@@ -2,6 +2,7 @@ const { runBoostTests } = require('./boost');
 const { runRepayTests } = require('./repay');
 const { runBoostOnPriceTests } = require('./boost-on-price');
 const { runRepayOnPriceTests } = require('./repay-on-price');
+const { runFullRepayOnPriceTests } = require('./full-repay-on-price');
 const { runCloseTests } = require('./close');
 
 describe('AaveV3  Full Strategy Tests', () => {
@@ -9,5 +10,6 @@ describe('AaveV3  Full Strategy Tests', () => {
     runRepayTests();
     runBoostOnPriceTests();
     runRepayOnPriceTests();
+    runFullRepayOnPriceTests();
     runCloseTests();
 });


### PR DESCRIPTION
### Summary

Add support for full repay on price. Meaning that now AaveV3OpenRatioCheck will support targetRatio 0. Effectively this means that user debt is paid in full and extra collateral is left in protocol to gain yield.


### Type of change

- [x] New Feature - A change that adds functionality.
- [ ] Bugfix - A change that resolves an issue.
- [ ] Tweak - A change that modifies existing features.
- [ ] Refactor - Code improvements without changing behavior.
- [ ] Performance - Optimizations for gas or execution efficiency.
- [ ] Documentation - Updates to docs, comments, or NatSpec.
- [ ] Tests - Adding or updating test coverage.
- [ ] Chore - Maintenance, dependencies, CI/CD, deployments or tooling updates.

### Details

_Provide any additional details if needed._

### References

_Link any existing PRs, such as SDK PRs related to this PR, or any additional references._

### Checks

#### For New Contracts

- [ ] Does the new contract have tests?
- [ ] Does the contract contain all the NatSpec needed (`@title`, `@notice`, `@param`, etc.)?
- [ ] Is the contract deployed and the address added to the JSON file?
- [ ] If the contract is registered, is the waitPeriod set correctly?
- [ ] Is the contract verified and added to the Tenderly dashboard?
- [ ] Is documentation written for the corresponding DFS action and added to GitBook?

#### For Modifications to Existing Contracts

- [x] If there were existing tests for the contract, are they adapted for the change and executed?
- [ ] Is the contract redeployed and added to the JSON file?
- [ ] If the contract is registered, is the waitPeriod set correctly?
- [ ] Is the contract verified and added to the Tenderly dashboard?
- [ ] If some parameters were changed and a breaking change was introduced, is the documentation updated on GitBook?

#### For Strategies

- [ ] Are new tests added for the strategy?
- [ ] Is the strategy deployed and added to the JSON file?
