### PR TITLE
feat: add aaveV4 delegate actions without sig

### DIFF
--- a/addresses/mainnet.json
+++ b/addresses/mainnet.json
@@ -5199,5 +5199,38 @@
         "changeTime": 0,
         "registryIds": [],
         "history": []
+    },
+    {
+        "name": "AaveV4DelegateBorrow",
+        "address": "0x4284B4e09c46Ee2b4E703dB8e5A2F892d12638e1",
+        "id": "0xaa70a0b5",
+        "path": "contracts/actions/aaveV4/AaveV4DelegateBorrow.sol",
+        "version": "1.0.0",
+        "inRegistry": true,
+        "changeTime": "86400",
+        "registryIds": [],
+        "history": []
+    },
+    {
+        "name": "AaveV4DelegateWithdraw",
+        "address": "0x5e7c404d46971E7BD3a95570A80Bc37F38bf9E29",
+        "id": "0xf3a0510b",
+        "path": "contracts/actions/aaveV4/AaveV4DelegateWithdraw.sol",
+        "version": "1.0.0",
+        "inRegistry": true,
+        "changeTime": "86400",
+        "registryIds": [],
+        "history": []
+    },
+    {
+        "name": "AaveV4DelegateSetUsingAsCollateral",
+        "address": "0xa97f8E483C147f27aE7370DeaC4E6585A37884A2",
+        "id": "0xe4860f02",
+        "path": "contracts/actions/aaveV4/AaveV4DelegateSetUsingAsCollateral.sol",
+        "version": "1.0.0",
+        "inRegistry": true,
+        "changeTime": "86400",
+        "registryIds": [],
+        "history": []
     }
 ]

--- a/addresses/mainnet.json
+++ b/addresses/mainnet.json
@@ -5232,5 +5232,16 @@
         "changeTime": "86400",
         "registryIds": [],
         "history": []
+    },
+    {
+        "name": "AaveV4SetUserManagers",
+        "address": "0x61e5d59bD82FFC61B916d2F2114eF671b17d0662",
+        "id": "0x8cc6d554",
+        "path": "contracts/actions/aaveV4/AaveV4SetUserManagers.sol",
+        "version": "1.0.0",
+        "inRegistry": true,
+        "changeTime": "86400",
+        "registryIds": [],
+        "history": []
     }
 ]

--- a/contracts/actions/aaveV4/AaveV4DelegateBorrow.sol
+++ b/contracts/actions/aaveV4/AaveV4DelegateBorrow.sol
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity =0.8.24;
+
+import { ITakerPositionManager } from "../../interfaces/protocols/aaveV4/ITakerPositionManager.sol";
+import { ActionBase } from "../ActionBase.sol";
+import { AaveV4Helper } from "./helpers/AaveV4Helper.sol";
+
+/// @title AaveV4DelegateBorrow
+/// @notice Approves a spender to borrow from the specified reserve on behalf of the wallet.
+contract AaveV4DelegateBorrow is ActionBase, AaveV4Helper {
+    /// @param spoke Address of the spoke.
+    /// @param reserveId Reserve id.
+    /// @param spender Address that will receive the borrow allowance.
+    /// @param amount Amount of borrow allowance.
+    struct Params {
+        address spoke;
+        uint256 reserveId;
+        address spender;
+        uint256 amount;
+    }
+
+    /// @inheritdoc ActionBase
+    function executeAction(
+        bytes memory _callData,
+        bytes32[] memory _subData,
+        uint8[] memory _paramMapping,
+        bytes32[] memory _returnValues
+    ) public payable virtual override returns (bytes32) {
+        Params memory params = parseInputs(_callData);
+
+        params.spoke = _parseParamAddr(params.spoke, _paramMapping[0], _subData, _returnValues);
+        params.reserveId =
+            _parseParamUint(params.reserveId, _paramMapping[1], _subData, _returnValues);
+        params.spender = _parseParamAddr(params.spender, _paramMapping[2], _subData, _returnValues);
+        params.amount = _parseParamUint(params.amount, _paramMapping[3], _subData, _returnValues);
+
+        (uint256 amount, bytes memory logData) = _delegateBorrow(params);
+        emit ActionEvent("AaveV4DelegateBorrow", logData);
+        return bytes32(amount);
+    }
+
+    /// @inheritdoc ActionBase
+    function executeActionDirect(bytes memory _callData) public payable override {
+        Params memory params = parseInputs(_callData);
+        (, bytes memory logData) = _delegateBorrow(params);
+        logger.logActionDirectEvent("AaveV4DelegateBorrow", logData);
+    }
+
+    /// @inheritdoc ActionBase
+    function actionType() public pure virtual override returns (uint8) {
+        return uint8(ActionType.STANDARD_ACTION);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                            ACTION LOGIC
+    //////////////////////////////////////////////////////////////*/
+    function _delegateBorrow(Params memory _params) internal returns (uint256, bytes memory) {
+        ITakerPositionManager(TAKER_POSITION_MANAGER)
+            .approveBorrow(_params.spoke, _params.reserveId, _params.spender, _params.amount);
+        return (_params.amount, abi.encode(_params));
+    }
+
+    function parseInputs(bytes memory _callData) public pure returns (Params memory params) {
+        params = abi.decode(_callData, (Params));
+    }
+}

--- a/contracts/actions/aaveV4/AaveV4DelegateSetUsingAsCollateral.sol
+++ b/contracts/actions/aaveV4/AaveV4DelegateSetUsingAsCollateral.sol
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity =0.8.24;
+
+import {
+    IConfigPositionManager
+} from "../../interfaces/protocols/aaveV4/IConfigPositionManager.sol";
+import { ActionBase } from "../ActionBase.sol";
+import { AaveV4Helper } from "./helpers/AaveV4Helper.sol";
+
+/// @title AaveV4DelegateSetUsingAsCollateral
+/// @notice Approves a delegatee to set using as collateral on behalf of the wallet.
+contract AaveV4DelegateSetUsingAsCollateral is ActionBase, AaveV4Helper {
+    /// @param spoke Address of the spoke.
+    /// @param delegatee Address that will receive the permission.
+    /// @param permission Whether the delegatee can set using as collateral.
+    struct Params {
+        address spoke;
+        address delegatee;
+        bool permission;
+    }
+
+    /// @inheritdoc ActionBase
+    function executeAction(
+        bytes memory _callData,
+        bytes32[] memory _subData,
+        uint8[] memory _paramMapping,
+        bytes32[] memory _returnValues
+    ) public payable virtual override returns (bytes32) {
+        Params memory params = parseInputs(_callData);
+
+        params.spoke = _parseParamAddr(params.spoke, _paramMapping[0], _subData, _returnValues);
+        params.delegatee =
+            _parseParamAddr(params.delegatee, _paramMapping[1], _subData, _returnValues);
+        params.permission = _parseParamUint(
+            params.permission ? 1 : 0, _paramMapping[2], _subData, _returnValues
+        ) == 1;
+
+        (uint256 permission, bytes memory logData) = _delegateSetUsingAsCollateral(params);
+        emit ActionEvent("AaveV4DelegateSetUsingAsCollateral", logData);
+        return bytes32(permission);
+    }
+
+    /// @inheritdoc ActionBase
+    function executeActionDirect(bytes memory _callData) public payable override {
+        Params memory params = parseInputs(_callData);
+        (, bytes memory logData) = _delegateSetUsingAsCollateral(params);
+        logger.logActionDirectEvent("AaveV4DelegateSetUsingAsCollateral", logData);
+    }
+
+    /// @inheritdoc ActionBase
+    function actionType() public pure virtual override returns (uint8) {
+        return uint8(ActionType.STANDARD_ACTION);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                            ACTION LOGIC
+    //////////////////////////////////////////////////////////////*/
+    function _delegateSetUsingAsCollateral(Params memory _params)
+        internal
+        returns (uint256, bytes memory)
+    {
+        IConfigPositionManager(CONFIG_POSITION_MANAGER)
+            .setCanSetUsingAsCollateralPermission(
+                _params.spoke, _params.delegatee, _params.permission
+            );
+        return (_params.permission ? 1 : 0, abi.encode(_params));
+    }
+
+    function parseInputs(bytes memory _callData) public pure returns (Params memory params) {
+        params = abi.decode(_callData, (Params));
+    }
+}

--- a/contracts/actions/aaveV4/AaveV4DelegateWithdraw.sol
+++ b/contracts/actions/aaveV4/AaveV4DelegateWithdraw.sol
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity =0.8.24;
+
+import { ITakerPositionManager } from "../../interfaces/protocols/aaveV4/ITakerPositionManager.sol";
+import { ActionBase } from "../ActionBase.sol";
+import { AaveV4Helper } from "./helpers/AaveV4Helper.sol";
+
+/// @title AaveV4DelegateWithdraw
+/// @notice Approves a spender to withdraw from the specified reserve on behalf of the wallet.
+contract AaveV4DelegateWithdraw is ActionBase, AaveV4Helper {
+    /// @param spoke Address of the spoke.
+    /// @param reserveId Reserve id.
+    /// @param spender Address that will receive the withdraw allowance.
+    /// @param amount Amount of withdraw allowance.
+    struct Params {
+        address spoke;
+        uint256 reserveId;
+        address spender;
+        uint256 amount;
+    }
+
+    /// @inheritdoc ActionBase
+    function executeAction(
+        bytes memory _callData,
+        bytes32[] memory _subData,
+        uint8[] memory _paramMapping,
+        bytes32[] memory _returnValues
+    ) public payable virtual override returns (bytes32) {
+        Params memory params = parseInputs(_callData);
+
+        params.spoke = _parseParamAddr(params.spoke, _paramMapping[0], _subData, _returnValues);
+        params.reserveId =
+            _parseParamUint(params.reserveId, _paramMapping[1], _subData, _returnValues);
+        params.spender = _parseParamAddr(params.spender, _paramMapping[2], _subData, _returnValues);
+        params.amount = _parseParamUint(params.amount, _paramMapping[3], _subData, _returnValues);
+
+        (uint256 amount, bytes memory logData) = _delegateWithdraw(params);
+        emit ActionEvent("AaveV4DelegateWithdraw", logData);
+        return bytes32(amount);
+    }
+
+    /// @inheritdoc ActionBase
+    function executeActionDirect(bytes memory _callData) public payable override {
+        Params memory params = parseInputs(_callData);
+        (, bytes memory logData) = _delegateWithdraw(params);
+        logger.logActionDirectEvent("AaveV4DelegateWithdraw", logData);
+    }
+
+    /// @inheritdoc ActionBase
+    function actionType() public pure virtual override returns (uint8) {
+        return uint8(ActionType.STANDARD_ACTION);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                            ACTION LOGIC
+    //////////////////////////////////////////////////////////////*/
+    function _delegateWithdraw(Params memory _params) internal returns (uint256, bytes memory) {
+        ITakerPositionManager(TAKER_POSITION_MANAGER)
+            .approveWithdraw(_params.spoke, _params.reserveId, _params.spender, _params.amount);
+        return (_params.amount, abi.encode(_params));
+    }
+
+    function parseInputs(bytes memory _callData) public pure returns (Params memory params) {
+        params = abi.decode(_callData, (Params));
+    }
+}

--- a/contracts/actions/aaveV4/AaveV4SetUserManagers.sol
+++ b/contracts/actions/aaveV4/AaveV4SetUserManagers.sol
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity =0.8.24;
+
+import { ISpoke } from "../../interfaces/protocols/aaveV4/ISpoke.sol";
+import { ActionBase } from "../ActionBase.sol";
+
+/// @title AaveV4SetUserManagers
+/// @notice Sets position managers for the user's wallet.
+contract AaveV4SetUserManagers is ActionBase {
+    /// @param spoke Address of the spoke.
+    /// @param updates The array of position manager updates.
+    struct Params {
+        address spoke;
+        ISpoke.PositionManagerUpdate[] updates;
+    }
+
+    /// @inheritdoc ActionBase
+    function executeAction(
+        bytes memory _callData,
+        bytes32[] memory _subData,
+        uint8[] memory _paramMapping,
+        bytes32[] memory _returnValues
+    ) public payable virtual override returns (bytes32) {
+        Params memory params = parseInputs(_callData);
+
+        params.spoke = _parseParamAddr(params.spoke, _paramMapping[0], _subData, _returnValues);
+
+        bytes memory logData = _setUserManagers(params);
+        emit ActionEvent("AaveV4SetUserManagers", logData);
+        return bytes32(0);
+    }
+
+    /// @inheritdoc ActionBase
+    function executeActionDirect(bytes memory _callData) public payable override {
+        Params memory params = parseInputs(_callData);
+        bytes memory logData = _setUserManagers(params);
+        logger.logActionDirectEvent("AaveV4SetUserManagers", logData);
+    }
+
+    /// @inheritdoc ActionBase
+    function actionType() public pure virtual override returns (uint8) {
+        return uint8(ActionType.STANDARD_ACTION);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                            ACTION LOGIC
+    //////////////////////////////////////////////////////////////*/
+    function _setUserManagers(Params memory _params) internal returns (bytes memory logData) {
+        for (uint256 i = 0; i < _params.updates.length; ++i) {
+            ISpoke(_params.spoke)
+                .setUserPositionManager(
+                    _params.updates[i].positionManager, _params.updates[i].approve
+                );
+        }
+
+        logData = abi.encode(_params);
+    }
+
+    function parseInputs(bytes memory _callData) public pure returns (Params memory params) {
+        params = abi.decode(_callData, (Params));
+    }
+}

--- a/test-sol/actions/aaveV4/AaveV4DelegateBorrow.t.sol
+++ b/test-sol/actions/aaveV4/AaveV4DelegateBorrow.t.sol
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity =0.8.24;
+
+import {
+    ITakerPositionManager
+} from "../../../contracts/interfaces/protocols/aaveV4/ITakerPositionManager.sol";
+import { SmartWallet } from "test-sol/utils/SmartWallet.sol";
+import { AaveV4DelegateBorrow } from "../../../contracts/actions/aaveV4/AaveV4DelegateBorrow.sol";
+import { AaveV4Encode } from "test-sol/utils/encode/AaveV4Encode.sol";
+import { AaveV4TestBase } from "./AaveV4TestBase.t.sol";
+
+contract TestAaveV4DelegateBorrow is AaveV4TestBase {
+    /*//////////////////////////////////////////////////////////////////////////
+                               CONTRACT UNDER TEST
+    //////////////////////////////////////////////////////////////////////////*/
+    AaveV4DelegateBorrow cut;
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                    VARIABLES
+    //////////////////////////////////////////////////////////////////////////*/
+    SmartWallet wallet;
+    address walletAddr;
+    address spender;
+    ITakerPositionManager takerPM;
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                  SETUP FUNCTION
+    //////////////////////////////////////////////////////////////////////////*/
+    function setUp() public override {
+        forkFromEnv("");
+
+        spender = vm.addr(SIGNER_PK);
+        wallet = new SmartWallet(spender);
+        walletAddr = wallet.walletAddr();
+
+        cut = new AaveV4DelegateBorrow();
+        takerPM = ITakerPositionManager(TAKER_POSITION_MANAGER);
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                     TESTS
+    //////////////////////////////////////////////////////////////////////////*/
+    function test_delegate_borrow_specific_amount() public {
+        uint256 amount = 1000e6;
+        assertEq(takerPM.borrowAllowance(CORE_SPOKE, CORE_RESERVE_ID_USDC, walletAddr, spender), 0);
+
+        _executeDelegateBorrow(CORE_RESERVE_ID_USDC, amount, false);
+
+        assertEq(
+            takerPM.borrowAllowance(CORE_SPOKE, CORE_RESERVE_ID_USDC, walletAddr, spender), amount
+        );
+    }
+
+    function test_delegate_borrow_max_amount() public {
+        _executeDelegateBorrow(CORE_RESERVE_ID_WETH, type(uint256).max, false);
+
+        assertEq(
+            takerPM.borrowAllowance(CORE_SPOKE, CORE_RESERVE_ID_WETH, walletAddr, spender),
+            type(uint256).max
+        );
+    }
+
+    function test_delegate_borrow_updates_allowance() public {
+        _executeDelegateBorrow(CORE_RESERVE_ID_USDC, 500e6, false);
+        assertEq(
+            takerPM.borrowAllowance(CORE_SPOKE, CORE_RESERVE_ID_USDC, walletAddr, spender), 500e6
+        );
+
+        _executeDelegateBorrow(CORE_RESERVE_ID_USDC, 1000e6, false);
+        assertEq(
+            takerPM.borrowAllowance(CORE_SPOKE, CORE_RESERVE_ID_USDC, walletAddr, spender), 1000e6
+        );
+    }
+
+    function test_delegate_borrow_direct() public {
+        uint256 amount = 1000e6;
+
+        _executeDelegateBorrow(CORE_RESERVE_ID_USDC, amount, true);
+
+        assertEq(
+            takerPM.borrowAllowance(CORE_SPOKE, CORE_RESERVE_ID_USDC, walletAddr, spender), amount
+        );
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                     HELPERS
+    //////////////////////////////////////////////////////////////////////////*/
+    function _executeDelegateBorrow(uint256 _reserveId, uint256 _amount, bool _isDirect) internal {
+        bytes memory callData = executeActionCalldata(
+            AaveV4Encode.delegateBorrow(CORE_SPOKE, _reserveId, spender, _amount), _isDirect
+        );
+
+        wallet.execute(address(cut), callData, 0);
+    }
+}

--- a/test-sol/actions/aaveV4/AaveV4DelegateSetUsingAsCollateral.t.sol
+++ b/test-sol/actions/aaveV4/AaveV4DelegateSetUsingAsCollateral.t.sol
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity =0.8.24;
+
+import {
+    IConfigPositionManager
+} from "../../../contracts/interfaces/protocols/aaveV4/IConfigPositionManager.sol";
+import { ISpoke } from "../../../contracts/interfaces/protocols/aaveV4/ISpoke.sol";
+import { SmartWallet } from "test-sol/utils/SmartWallet.sol";
+import {
+    AaveV4DelegateSetUsingAsCollateral
+} from "../../../contracts/actions/aaveV4/AaveV4DelegateSetUsingAsCollateral.sol";
+import { AaveV4Encode } from "test-sol/utils/encode/AaveV4Encode.sol";
+import { AaveV4TestBase } from "./AaveV4TestBase.t.sol";
+
+contract TestAaveV4DelegateSetUsingAsCollateral is AaveV4TestBase {
+    /*//////////////////////////////////////////////////////////////////////////
+                               CONTRACT UNDER TEST
+    //////////////////////////////////////////////////////////////////////////*/
+    AaveV4DelegateSetUsingAsCollateral cut;
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                    VARIABLES
+    //////////////////////////////////////////////////////////////////////////*/
+    SmartWallet wallet;
+    address walletAddr;
+    address delegatee;
+    IConfigPositionManager configPM;
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                  SETUP FUNCTION
+    //////////////////////////////////////////////////////////////////////////*/
+    function setUp() public override {
+        forkFromEnv("");
+
+        delegatee = vm.addr(SIGNER_PK);
+        wallet = new SmartWallet(delegatee);
+        walletAddr = wallet.walletAddr();
+
+        cut = new AaveV4DelegateSetUsingAsCollateral();
+        configPM = IConfigPositionManager(CONFIG_POSITION_MANAGER);
+
+        vm.prank(walletAddr);
+        ISpoke(CORE_SPOKE).setUserPositionManager(CONFIG_POSITION_MANAGER, true);
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                     TESTS
+    //////////////////////////////////////////////////////////////////////////*/
+    function test_delegate_set_using_as_collateral_permission_true() public {
+        assertFalse(
+            configPM.getConfigPermissions(CORE_SPOKE, delegatee, walletAddr).canSetUsingAsCollateral
+        );
+
+        _executeDelegateSetUsingAsCollateral(true, false);
+
+        assertTrue(
+            configPM.getConfigPermissions(CORE_SPOKE, delegatee, walletAddr).canSetUsingAsCollateral
+        );
+    }
+
+    function test_delegate_set_using_as_collateral_permission_false() public {
+        _executeDelegateSetUsingAsCollateral(true, false);
+        assertTrue(
+            configPM.getConfigPermissions(CORE_SPOKE, delegatee, walletAddr).canSetUsingAsCollateral
+        );
+
+        _executeDelegateSetUsingAsCollateral(false, false);
+
+        assertFalse(
+            configPM.getConfigPermissions(CORE_SPOKE, delegatee, walletAddr).canSetUsingAsCollateral
+        );
+    }
+
+    function test_delegate_set_using_as_collateral_permission_updates() public {
+        _executeDelegateSetUsingAsCollateral(true, false);
+        assertTrue(
+            configPM.getConfigPermissions(CORE_SPOKE, delegatee, walletAddr).canSetUsingAsCollateral
+        );
+
+        _executeDelegateSetUsingAsCollateral(false, false);
+        assertFalse(
+            configPM.getConfigPermissions(CORE_SPOKE, delegatee, walletAddr).canSetUsingAsCollateral
+        );
+
+        _executeDelegateSetUsingAsCollateral(true, false);
+        assertTrue(
+            configPM.getConfigPermissions(CORE_SPOKE, delegatee, walletAddr).canSetUsingAsCollateral
+        );
+    }
+
+    function test_delegate_set_using_as_collateral_direct() public {
+        _executeDelegateSetUsingAsCollateral(true, true);
+
+        assertTrue(
+            configPM.getConfigPermissions(CORE_SPOKE, delegatee, walletAddr).canSetUsingAsCollateral
+        );
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                     HELPERS
+    //////////////////////////////////////////////////////////////////////////*/
+    function _executeDelegateSetUsingAsCollateral(bool _permission, bool _isDirect) internal {
+        bytes memory callData = executeActionCalldata(
+            AaveV4Encode.delegateSetUsingAsCollateral(CORE_SPOKE, delegatee, _permission), _isDirect
+        );
+
+        wallet.execute(address(cut), callData, 0);
+    }
+}

--- a/test-sol/actions/aaveV4/AaveV4DelegateWithdraw.t.sol
+++ b/test-sol/actions/aaveV4/AaveV4DelegateWithdraw.t.sol
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity =0.8.24;
+
+import {
+    ITakerPositionManager
+} from "../../../contracts/interfaces/protocols/aaveV4/ITakerPositionManager.sol";
+import { SmartWallet } from "test-sol/utils/SmartWallet.sol";
+import {
+    AaveV4DelegateWithdraw
+} from "../../../contracts/actions/aaveV4/AaveV4DelegateWithdraw.sol";
+import { AaveV4Encode } from "test-sol/utils/encode/AaveV4Encode.sol";
+import { AaveV4TestBase } from "./AaveV4TestBase.t.sol";
+
+contract TestAaveV4DelegateWithdraw is AaveV4TestBase {
+    /*//////////////////////////////////////////////////////////////////////////
+                               CONTRACT UNDER TEST
+    //////////////////////////////////////////////////////////////////////////*/
+    AaveV4DelegateWithdraw cut;
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                    VARIABLES
+    //////////////////////////////////////////////////////////////////////////*/
+    SmartWallet wallet;
+    address walletAddr;
+    address spender;
+    ITakerPositionManager takerPM;
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                  SETUP FUNCTION
+    //////////////////////////////////////////////////////////////////////////*/
+    function setUp() public override {
+        forkFromEnv("");
+
+        spender = vm.addr(SIGNER_PK);
+        wallet = new SmartWallet(spender);
+        walletAddr = wallet.walletAddr();
+
+        cut = new AaveV4DelegateWithdraw();
+        takerPM = ITakerPositionManager(TAKER_POSITION_MANAGER);
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                     TESTS
+    //////////////////////////////////////////////////////////////////////////*/
+    function test_delegate_withdraw_specific_amount() public {
+        uint256 amount = 1000e6;
+        assertEq(
+            takerPM.withdrawAllowance(CORE_SPOKE, CORE_RESERVE_ID_USDC, walletAddr, spender), 0
+        );
+
+        _executeDelegateWithdraw(CORE_RESERVE_ID_USDC, amount, false);
+
+        assertEq(
+            takerPM.withdrawAllowance(CORE_SPOKE, CORE_RESERVE_ID_USDC, walletAddr, spender), amount
+        );
+    }
+
+    function test_delegate_withdraw_max_amount() public {
+        _executeDelegateWithdraw(CORE_RESERVE_ID_WETH, type(uint256).max, false);
+
+        assertEq(
+            takerPM.withdrawAllowance(CORE_SPOKE, CORE_RESERVE_ID_WETH, walletAddr, spender),
+            type(uint256).max
+        );
+    }
+
+    function test_delegate_withdraw_updates_allowance() public {
+        _executeDelegateWithdraw(CORE_RESERVE_ID_USDC, 500e6, false);
+        assertEq(
+            takerPM.withdrawAllowance(CORE_SPOKE, CORE_RESERVE_ID_USDC, walletAddr, spender), 500e6
+        );
+
+        _executeDelegateWithdraw(CORE_RESERVE_ID_USDC, 1000e6, false);
+        assertEq(
+            takerPM.withdrawAllowance(CORE_SPOKE, CORE_RESERVE_ID_USDC, walletAddr, spender), 1000e6
+        );
+    }
+
+    function test_delegate_withdraw_direct() public {
+        uint256 amount = 1000e6;
+
+        _executeDelegateWithdraw(CORE_RESERVE_ID_USDC, amount, true);
+
+        assertEq(
+            takerPM.withdrawAllowance(CORE_SPOKE, CORE_RESERVE_ID_USDC, walletAddr, spender), amount
+        );
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                     HELPERS
+    //////////////////////////////////////////////////////////////////////////*/
+    function _executeDelegateWithdraw(uint256 _reserveId, uint256 _amount, bool _isDirect)
+        internal
+    {
+        bytes memory callData = executeActionCalldata(
+            AaveV4Encode.delegateWithdraw(CORE_SPOKE, _reserveId, spender, _amount), _isDirect
+        );
+
+        wallet.execute(address(cut), callData, 0);
+    }
+}

--- a/test-sol/actions/aaveV4/AaveV4SetUserManagers.t.sol
+++ b/test-sol/actions/aaveV4/AaveV4SetUserManagers.t.sol
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity =0.8.24;
+
+import { ISpoke } from "../../../contracts/interfaces/protocols/aaveV4/ISpoke.sol";
+import { SmartWallet } from "test-sol/utils/SmartWallet.sol";
+import { AaveV4SetUserManagers } from "../../../contracts/actions/aaveV4/AaveV4SetUserManagers.sol";
+import { AaveV4Encode } from "test-sol/utils/encode/AaveV4Encode.sol";
+import { AaveV4TestBase } from "./AaveV4TestBase.t.sol";
+
+contract TestAaveV4SetUserManagers is AaveV4TestBase {
+    /*//////////////////////////////////////////////////////////////////////////
+                               CONTRACT UNDER TEST
+    //////////////////////////////////////////////////////////////////////////*/
+    AaveV4SetUserManagers cut;
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                    VARIABLES
+    //////////////////////////////////////////////////////////////////////////*/
+    SmartWallet wallet;
+    address walletAddr;
+    ISpoke spoke;
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                  SETUP FUNCTION
+    //////////////////////////////////////////////////////////////////////////*/
+    function setUp() public override {
+        forkFromEnv("");
+
+        wallet = new SmartWallet(bob);
+        walletAddr = wallet.walletAddr();
+
+        cut = new AaveV4SetUserManagers();
+        spoke = ISpoke(CORE_SPOKE);
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                     TESTS
+    //////////////////////////////////////////////////////////////////////////*/
+    function test_approve_single_manager() public {
+        assertFalse(spoke.isPositionManager(walletAddr, GIVER_POSITION_MANAGER));
+
+        _executeSetManagers(_singleUpdate(GIVER_POSITION_MANAGER, true), false);
+
+        assertTrue(spoke.isPositionManager(walletAddr, GIVER_POSITION_MANAGER));
+    }
+
+    function test_approve_multiple_managers() public {
+        ISpoke.PositionManagerUpdate[] memory updates = new ISpoke.PositionManagerUpdate[](3);
+        updates[0] = ISpoke.PositionManagerUpdate(GIVER_POSITION_MANAGER, true);
+        updates[1] = ISpoke.PositionManagerUpdate(TAKER_POSITION_MANAGER, true);
+        updates[2] = ISpoke.PositionManagerUpdate(CONFIG_POSITION_MANAGER, true);
+
+        _executeSetManagers(updates, false);
+
+        assertTrue(spoke.isPositionManager(walletAddr, GIVER_POSITION_MANAGER));
+        assertTrue(spoke.isPositionManager(walletAddr, TAKER_POSITION_MANAGER));
+        assertTrue(spoke.isPositionManager(walletAddr, CONFIG_POSITION_MANAGER));
+    }
+
+    function test_revoke_single_manager() public {
+        _executeSetManagers(_singleUpdate(GIVER_POSITION_MANAGER, true), false);
+        assertTrue(spoke.isPositionManager(walletAddr, GIVER_POSITION_MANAGER));
+
+        _executeSetManagers(_singleUpdate(GIVER_POSITION_MANAGER, false), false);
+
+        assertFalse(spoke.isPositionManager(walletAddr, GIVER_POSITION_MANAGER));
+    }
+
+    function test_approve_already_approved_manager() public {
+        _executeSetManagers(_singleUpdate(GIVER_POSITION_MANAGER, true), false);
+        assertTrue(spoke.isPositionManager(walletAddr, GIVER_POSITION_MANAGER));
+
+        _executeSetManagers(_singleUpdate(GIVER_POSITION_MANAGER, true), false);
+
+        assertTrue(spoke.isPositionManager(walletAddr, GIVER_POSITION_MANAGER));
+    }
+
+    function test_revoke_not_approved_manager() public {
+        assertFalse(spoke.isPositionManager(walletAddr, GIVER_POSITION_MANAGER));
+
+        _executeSetManagers(_singleUpdate(GIVER_POSITION_MANAGER, false), false);
+
+        assertFalse(spoke.isPositionManager(walletAddr, GIVER_POSITION_MANAGER));
+    }
+
+    function test_set_user_managers_direct() public {
+        _executeSetManagers(_singleUpdate(GIVER_POSITION_MANAGER, true), true);
+
+        assertTrue(spoke.isPositionManager(walletAddr, GIVER_POSITION_MANAGER));
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                     HELPERS
+    //////////////////////////////////////////////////////////////////////////*/
+    function _executeSetManagers(ISpoke.PositionManagerUpdate[] memory _updates, bool _isDirect)
+        internal
+    {
+        bytes memory callData =
+            executeActionCalldata(AaveV4Encode.setUserManagers(CORE_SPOKE, _updates), _isDirect);
+
+        wallet.execute(address(cut), callData, 0);
+    }
+
+    function _singleUpdate(address _positionManager, bool _approve)
+        internal
+        pure
+        returns (ISpoke.PositionManagerUpdate[] memory updates)
+    {
+        updates = new ISpoke.PositionManagerUpdate[](1);
+        updates[0] = ISpoke.PositionManagerUpdate(_positionManager, _approve);
+    }
+}

--- a/test-sol/utils/encode/AaveV4Encode.sol
+++ b/test-sol/utils/encode/AaveV4Encode.sol
@@ -30,6 +30,13 @@ import {
 import {
     AaveV4DelegateSetUsingAsCollateralWithSig
 } from "../../../contracts/actions/aaveV4/AaveV4DelegateSetUsingAsCollateralWithSig.sol";
+import { AaveV4DelegateBorrow } from "../../../contracts/actions/aaveV4/AaveV4DelegateBorrow.sol";
+import {
+    AaveV4DelegateWithdraw
+} from "../../../contracts/actions/aaveV4/AaveV4DelegateWithdraw.sol";
+import {
+    AaveV4DelegateSetUsingAsCollateral
+} from "../../../contracts/actions/aaveV4/AaveV4DelegateSetUsingAsCollateral.sol";
 
 library AaveV4Encode {
     function supply(
@@ -176,12 +183,36 @@ library AaveV4Encode {
         );
     }
 
+    function delegateBorrow(address _spoke, uint256 _reserveId, address _spender, uint256 _amount)
+        public
+        pure
+        returns (bytes memory params)
+    {
+        params = abi.encode(
+            AaveV4DelegateBorrow.Params({
+                spoke: _spoke, reserveId: _reserveId, spender: _spender, amount: _amount
+            })
+        );
+    }
+
     function delegateWithdrawWithSig(
         ITakerPositionManager.WithdrawPermit memory _permit,
         bytes memory _signature
     ) public pure returns (bytes memory params) {
         params = abi.encode(
             AaveV4DelegateWithdrawWithSig.Params({ permit: _permit, signature: _signature })
+        );
+    }
+
+    function delegateWithdraw(address _spoke, uint256 _reserveId, address _spender, uint256 _amount)
+        public
+        pure
+        returns (bytes memory params)
+    {
+        params = abi.encode(
+            AaveV4DelegateWithdraw.Params({
+                spoke: _spoke, reserveId: _reserveId, spender: _spender, amount: _amount
+            })
         );
     }
 
@@ -192,6 +223,18 @@ library AaveV4Encode {
         params = abi.encode(
             AaveV4DelegateSetUsingAsCollateralWithSig.Params({
                 permit: _permit, signature: _signature
+            })
+        );
+    }
+
+    function delegateSetUsingAsCollateral(address _spoke, address _delegatee, bool _permission)
+        public
+        pure
+        returns (bytes memory params)
+    {
+        params = abi.encode(
+            AaveV4DelegateSetUsingAsCollateral.Params({
+                spoke: _spoke, delegatee: _delegatee, permission: _permission
             })
         );
     }

--- a/test-sol/utils/encode/AaveV4Encode.sol
+++ b/test-sol/utils/encode/AaveV4Encode.sol
@@ -21,6 +21,7 @@ import { AaveV4RatioCheck } from "../../../contracts/actions/checkers/AaveV4Rati
 import {
     AaveV4SetUserManagersWithSig
 } from "../../../contracts/actions/aaveV4/AaveV4SetUserManagersWithSig.sol";
+import { AaveV4SetUserManagers } from "../../../contracts/actions/aaveV4/AaveV4SetUserManagers.sol";
 import {
     AaveV4DelegateBorrowWithSig
 } from "../../../contracts/actions/aaveV4/AaveV4DelegateBorrowWithSig.sol";
@@ -172,6 +173,14 @@ library AaveV4Encode {
                 updates: _updates
             })
         );
+    }
+
+    function setUserManagers(address _spoke, ISpoke.PositionManagerUpdate[] memory _updates)
+        public
+        pure
+        returns (bytes memory params)
+    {
+        params = abi.encode(AaveV4SetUserManagers.Params({ spoke: _spoke, updates: _updates }));
     }
 
     function delegateBorrowWithSig(


### PR DESCRIPTION
### Summary

Adds new delegate actions that does not use signatures.

- AaveV4DelegateBorrow
- AaveV4DelegateWithdraw
- AaveV4DelegateSetUsingAsCollateral
- AaveV4SetUserManagers

### Type of change

- [X] New Feature - A change that adds functionality.
- [ ] Bugfix - A change that resolves an issue.
- [ ] Tweak - A change that modifies existing features.
- [ ] Refactor - Code improvements without changing behavior.
- [ ] Performance - Optimizations for gas or execution efficiency.
- [ ] Documentation - Updates to docs, comments, or NatSpec.
- [ ] Tests - Adding or updating test coverage.
- [ ] Chore - Maintenance, dependencies, CI/CD, deployments or tooling updates.

### References

SDK: https://github.com/defisaver/defisaver-sdk/pull/185

### Checks

#### For New Contracts

- [X] Does the new contract have tests?
- [X] Does the contract contain all the NatSpec needed (`@title`, `@notice`, `@param`, etc.)?
- [x] Is the contract deployed and the address added to the JSON file?
- [x] If the contract is registered, is the waitPeriod set correctly?
- [x] Is the contract verified and added to the Tenderly dashboard?
- [x] Is documentation written for the corresponding DFS action and added to GitBook?